### PR TITLE
Fixed bug by moving peripheral struct declaration out from its module into lib.rs

### DIFF
--- a/templates/rust/lib.tera
+++ b/templates/rust/lib.tera
@@ -38,11 +38,10 @@ pub use {{module_name}} as csfr_cpu;
 
 {% for name,p in ir.peripheral_mod %}
 {%- set module_name = p.name | to_mod_id -%}
-#[derive(Copy, Clone, Eq, PartialEq)] {# Peripheral definition#}
 {% set peri_struct = p.name | to_struct_id -%}
+#[cfg(feature = "{{module_name}}")] {# Peripheral definition #}
+#[derive(Copy, Clone, Eq, PartialEq)] 
 pub struct {{ peri_struct }}(*mut u8);
-unsafe impl core::marker::Send for {{ peri_struct }} {}
-unsafe impl core::marker::Sync for {{ peri_struct }} {}
 {# Peripheral instances #}
 {%- set module_struct = p.name | to_struct_id -%}
 {%- set full_path_struct = "self::" ~ module_struct -%}

--- a/templates/rust/lib.tera
+++ b/templates/rust/lib.tera
@@ -1,3 +1,4 @@
+{% import "macros.tera" as macros %}
 /*
 {{ir.license_text}}
 */
@@ -5,7 +6,7 @@
 #![cfg_attr(not(feature = "tracing"), no_std)]
 {%- else %}
 #![no_std]
-{%- endif %}
+{%- endif %} {# tracing #}
 {% if target=="Aurix" %}
 #![cfg_attr(target_arch = "tricore", feature(stdsimd))]
 {% endif %}
@@ -19,12 +20,12 @@ pub use common::*;
 pub mod reg_name;
 #[cfg(feature = "tracing")]
 pub mod tracing;
-{% endif %}
+{% endif %} {# tracing #}
 {% for peri_mod_name, peri in ir.peripheral_mod -%}
 {%- set module_name = peri.name | to_mod_id -%}
 #[cfg(feature = "{{module_name}}")]
 pub mod {{module_name}};
-{% endfor -%}
+{% endfor -%} {# for peri_mod_name, peri in ir.peripheral_mod #}
 {% if ir_csfr %}
 {% for peri_mod_name, peri in ir_csfr.peripheral_mod -%}
 {%- set module_name = peri.name | to_mod_id -%}
@@ -35,18 +36,23 @@ pub use {{module_name}} as csfr_cpu;
 {% endfor -%}
 {% endif %}
 
-
 {% for name,p in ir.peripheral_mod %}
 {%- set module_name = p.name | to_mod_id -%}
+#[derive(Copy, Clone, Eq, PartialEq)] {# Peripheral definition#}
+{% set peri_struct = p.name | to_struct_id -%}
+pub struct {{ peri_struct }}(*mut u8);
+unsafe impl core::marker::Send for {{ peri_struct }} {}
+unsafe impl core::marker::Sync for {{ peri_struct }} {}
+{# Peripheral instances #}
 {%- set module_struct = p.name | to_struct_id -%}
-{%- set full_path_struct = module_name ~ "::" ~ module_struct -%}
+{%- set full_path_struct = "self::" ~ module_struct -%}
 #[cfg(feature = "{{module_name}}")]
 {%- if p.base_addr | length == 1 %}
 pub const {{name | upper}}: {{full_path_struct}} = {{full_path_struct}}({{p.base_addr[0] | to_hex }}u32 as _);
 {% else %}
 pub const {{name | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [{%- for addr in p.base_addr %}  {{full_path_struct}}({{addr | to_hex }}u32 as _), {% endfor -%}];
 {%- endif -%}
-{%- endfor -%}
+{%- endfor -%} {# for name,p in ir.peripheral_mod #}
 {% if ir_csfr %}
 #[cfg(any(
 {%- set module_struct = "csfr_cpu" | to_struct_id -%}
@@ -129,7 +135,7 @@ pub struct Peripherals {
     {% for name,p in ir.peripheral_mod %}
     {%- set module_name = p.name | to_mod_id -%}
     {%- set module_struct = p.name | to_struct_id -%}
-    {%- set full_path_struct = module_name ~ "::" ~ module_struct -%}
+    {%- set full_path_struct = "self::" ~ module_struct -%}
     #[cfg(feature = "{{module_name}}")]
     {%- if p.base_addr | length == 1 %}
     pub {{name | upper}}: {{full_path_struct}},

--- a/templates/rust/peri_mod.tera
+++ b/templates/rust/peri_mod.tera
@@ -11,6 +11,8 @@ use crate::common::{*};
 use crate::common::sealed;
 #[doc = r"{{peri.description | svd_description_to_doc}}"]
 {% set peri_struct = peri.name | to_struct_id -%}
+unsafe impl core::marker::Send for super::{{ peri_struct }} {}
+unsafe impl core::marker::Sync for super::{{ peri_struct }} {}
 impl super::{{ peri_struct }} {
 {%- for register_name,reg in peri.registers %}
 {{macros::register_func(types_mod="self",reg=reg)}}

--- a/templates/rust/peri_mod.tera
+++ b/templates/rust/peri_mod.tera
@@ -10,12 +10,8 @@ use crate::common::{*};
 #[allow(unused_imports)]
 use crate::common::sealed;
 #[doc = r"{{peri.description | svd_description_to_doc}}"]
-#[derive(Copy, Clone, Eq, PartialEq)]
 {% set peri_struct = peri.name | to_struct_id -%}
-pub struct {{ peri_struct }}(pub(super) *mut u8);
-unsafe impl core::marker::Send for {{ peri_struct }} {}
-unsafe impl core::marker::Sync for {{ peri_struct }} {}
-impl {{ peri_struct }} {
+impl super::{{ peri_struct }} {
 {%- for register_name,reg in peri.registers %}
 {{macros::register_func(types_mod="self",reg=reg)}}
 {% endfor -%}

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -508,7 +508,7 @@
 				</register>
 				<register>
 					<name>TIMER</name>
-					<description>Register to test when peripheral has same naem as register</description>
+					<description>Register to test when peripheral has same name as register</description>
 					<addressOffset>0x2000</addressOffset>
 					<access>read-write</access>
 				</register>

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -721,7 +721,7 @@
 				</register>
 				<cluster>
 					<name>UART</name>
-					<description>Cluster to test when peripheral has same naem as register</description>
+					<description>Cluster to test when peripheral has same name as register</description>
 					<addressOffset>0x1000</addressOffset>
 					<register>
 						<name>UART</name>

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -221,7 +221,7 @@
 						</field>
 						<field>
 							<dim>8</dim>
-							<dimIncrement>1</dimIncrement>
+							<dimIncrement>2</dimIncrement>
 							<name>Field%sArray</name>
 							<description>Array of bitfields</description>
 							<bitRange>[17:16]</bitRange>
@@ -506,6 +506,12 @@
 						</field>
 					</fields>
 				</register>
+				<register>
+					<name>TIMER</name>
+					<description>Register to test when peripheral has same naem as register</description>
+					<addressOffset>0x2000</addressOffset>
+					<access>read-write</access>
+				</register>
 				<cluster>
 					<name>Cluster1</name>
 					<description>Test Cluster</description>
@@ -593,6 +599,11 @@
 			<description>Test cluster</description>
 			<baseAddress>0x50000000</baseAddress>
 			<access>read-write</access>
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x1000000</size>
+				<usage>registers</usage>
+			</addressBlock>
 			<interrupt>
 				<name>UartInt</name>
 				<description>Uart interrupt</description>
@@ -601,7 +612,7 @@
 			<registers>
 				<register>
 					<dim>2</dim>
-					<dimIncrement>0x100</dimIncrement>
+					<dimIncrement>0x4</dimIncrement>
 					<name>Reg1_[%s]</name>
 					<description>read-write reg</description>
 					<addressOffset>0x0</addressOffset>
@@ -667,7 +678,7 @@
 							<name>Boolenum</name>
 							<description>Boolean with enum</description>
 							<lsb>9</lsb>
-							<msb>16</msb>
+							<msb>15</msb>
 							<access>read-write</access>
 							<enumeratedValues>
 								<enumeratedValue>
@@ -708,6 +719,24 @@
 					<resetValue>0x0000000</resetValue>
 					<resetMask>0xFFFFFFFF</resetMask>
 				</register>
+				<cluster>
+					<name>UART</name>
+					<description>Cluster to test when peripheral has same naem as register</description>
+					<addressOffset>0x1000</addressOffset>
+					<register>
+						<name>UART</name>
+						<addressOffset>0x00</addressOffset>
+						<access>read-write</access>
+						<fields>
+							<field>
+								<name>UART</name>
+								<lsb>0</lsb>
+								<msb>2</msb>
+								<access>read-write</access>
+							</field>
+						</fields>
+					</register>
+				</cluster>
 			</registers>
 		</peripheral>
 		<!-- UART 0-->
@@ -767,7 +796,7 @@
 			<name>EscapeTest</name>
 			<version>1.0</version>
 			<description>Fake peripheral containing register with characters that may need to be escaped (and some UTF-8) when documentation is inserted.</description>
-			<baseAddress>0x60000000</baseAddress>
+			<baseAddress>0x70000000</baseAddress>
 			<access>read-write</access>
 			<addressBlock>
 				<offset>0</offset>


### PR DESCRIPTION
Modified simple.xml to reproduce the issue when a register has same name as peripheral. (added also a cluster with same name as peripheral.)

Fixed simple.xml in order to have no error from svdconv tool.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Provide the information we need to review your PR. What problem does the pull request solve? "Bug fix" is not a good description.

Related Issue
If you opened an issue before creating the PR, point to it here.

Context
What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.