### PR TITLE
Support unrolling of arrayed registers within csfr peripherals

### DIFF
--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -47,6 +47,12 @@ pub const fn {{reg.name | to_func_id }}(&self) -> [crate::common::Reg<{{reg_stru
 pub const fn {{reg.name | to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
     unsafe { crate::common::RegCore::new() }
 }
+{%- else -%}
+{%- for index in range(end=reg.dim) -%}
+pub const fn {{reg.name~index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+index*reg.dim_increment | to_hex }}usize> {
+    unsafe { crate::common::RegCore::new() }
+}
+{% endfor -%}
 {%- endif -%}
 {%- endmacro -%}
 


### PR DESCRIPTION
Support unrolling of arrayed registers within csfr peripherals, e.g Ay[%s], Dy[%s]

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
