### PR TITLE
15 generated code compilation fails if svd peripheral name string is the same when converted in pascal case and full upper case

### DIFF
--- a/src/rust_gen/xml2ir.rs
+++ b/src/rust_gen/xml2ir.rs
@@ -94,8 +94,8 @@ struct Visitor {
 impl Visitor {
     /// Create the intermediate representation of device used by template engine
     fn visit_device(&mut self, device: &svd::Device) {
-        self.device.name = device.name.clone();
-        self.device.description = device.description.clone();
+        self.device.name.clone_from(&device.name);
+        self.device.description.clone_from(&device.description);
 
         for peripheral in device.peripherals.iter() {
             let name = peripheral.name().to_internal_ident();
@@ -448,7 +448,7 @@ fn get_values_types(field: &svd::Field) -> Option<EnumeratedValueType> {
             let value = if let Some(value) = val_entry.value {
                 value
             } else {
-                panic!("Unsupport is default, all value in enumeration shall have a value defined")
+                panic!("Default value is unsupported, all value in enumeration shall have a value defined")
             };
 
             values.push(EnumeratedSingleValue {

--- a/src/svd_util.rs
+++ b/src/svd_util.rs
@@ -23,7 +23,7 @@ impl ExpandedName for svd::Register {
             svd::MaybeArray::Single(info) => info.name.clone(),
             svd::MaybeArray::Array(info, dim_info) => svd::register::expand(info, dim_info)
                 .next()
-                .unwrap_or_else(|| panic!("Register {} is array of size 0",self.name))
+                .unwrap_or_else(|| panic!("Register {} is array of size 0", self.name))
                 .name
                 .to_string(),
         }
@@ -36,7 +36,7 @@ impl ExpandedName for svd::Peripheral {
             svd::MaybeArray::Single(info) => info.name.clone(),
             svd::MaybeArray::Array(info, dim_info) => svd::peripheral::expand(info, dim_info)
                 .next()
-                .unwrap_or_else(|| panic!("Peripheral {} is array of size 0",self.name))
+                .unwrap_or_else(|| panic!("Peripheral {} is array of size 0", self.name))
                 .name
                 .to_string(),
         }

--- a/src/svd_util.rs
+++ b/src/svd_util.rs
@@ -1,45 +1,5 @@
 use svd_parser::svd;
 
-pub trait PeripheralClusterT: svd::Name + svd::Description {
-    fn get_clusters(&self) -> svd::registercluster::ClusterIter<'_>;
-    fn get_registers(&self) -> svd::registercluster::RegisterIter<'_>;
-    fn struct_name(&self) -> String;
-}
-
-impl PeripheralClusterT for svd::Peripheral {
-    fn get_clusters(&self) -> svd::registercluster::ClusterIter<'_> {
-        self.clusters()
-    }
-
-    fn get_registers(&self) -> svd::registercluster::RegisterIter<'_> {
-        self.registers()
-    }
-
-    fn struct_name(&self) -> String {
-        match self.header_struct_name {
-            Some(ref struct_name) => struct_name.clone(),
-            None => self.name.clone(),
-        }
-    }
-}
-
-impl PeripheralClusterT for svd::Cluster {
-    fn get_clusters(&self) -> svd::registercluster::ClusterIter<'_> {
-        self.clusters()
-    }
-
-    fn get_registers(&self) -> svd::registercluster::RegisterIter<'_> {
-        self.registers()
-    }
-
-    fn struct_name(&self) -> String {
-        match self.header_struct_name {
-            Some(ref struct_name) => struct_name.clone(),
-            None => self.name.clone(),
-        }
-    }
-}
-
 pub trait ExpandedName: svd_parser::svd::Name {
     fn get_expanded_name(&self) -> String;
 }
@@ -63,7 +23,7 @@ impl ExpandedName for svd::Register {
             svd::MaybeArray::Single(info) => info.name.clone(),
             svd::MaybeArray::Array(info, dim_info) => svd::register::expand(info, dim_info)
                 .next()
-                .expect("Empty")
+                .unwrap_or_else(|| panic!("Register {} is array of size 0",self.name))
                 .name
                 .to_string(),
         }
@@ -76,7 +36,7 @@ impl ExpandedName for svd::Peripheral {
             svd::MaybeArray::Single(info) => info.name.clone(),
             svd::MaybeArray::Array(info, dim_info) => svd::peripheral::expand(info, dim_info)
                 .next()
-                .expect("Empty")
+                .unwrap_or_else(|| panic!("Peripheral {} is array of size 0",self.name))
                 .name
                 .to_string(),
         }

--- a/templates/rust/aurix_core.tera
+++ b/templates/rust/aurix_core.tera
@@ -13,7 +13,7 @@ use crate::common::sealed;
 #[derive(Copy, Clone, Eq, PartialEq)]
 {% set peri_struct = "CsfrCpu" | to_struct_id -%}
 {% set reg_base_addr = peri.base_addr[0]  -%}
-pub struct {{ peri_struct }}(pub(super) *mut u8);
+pub struct {{ peri_struct }}{pub(super) ptr: *mut u8}
 unsafe impl core::marker::Send for CsfrCpu  {}
 unsafe impl core::marker::Sync for CsfrCpu  {}
 impl CsfrCpu {

--- a/templates/rust/common.tera
+++ b/templates/rust/common.tera
@@ -30,7 +30,7 @@ pub(crate) mod sealed {
             fn cast_from(val: A) -> Self;
         }
         
-            impl CastFrom<u64> for u8 {
+    impl CastFrom<u64> for u8 {
         #[inline(always)]
         fn cast_from(val: u64) -> Self {
             val as Self

--- a/templates/rust/lib.tera
+++ b/templates/rust/lib.tera
@@ -41,15 +41,15 @@ pub use {{module_name}} as csfr_cpu;
 {% set peri_struct = p.name | to_struct_id -%}
 #[cfg(feature = "{{module_name}}")] {# Peripheral definition #}
 #[derive(Copy, Clone, Eq, PartialEq)] 
-pub struct {{ peri_struct }}(*mut u8);
+pub struct {{ peri_struct }}{ptr:*mut u8}
 {# Peripheral instances #}
 {%- set module_struct = p.name | to_struct_id -%}
 {%- set full_path_struct = "self::" ~ module_struct -%}
 #[cfg(feature = "{{module_name}}")]
 {%- if p.base_addr | length == 1 %}
-pub const {{name | upper}}: {{full_path_struct}} = {{full_path_struct}}({{p.base_addr[0] | to_hex }}u32 as _);
+pub const {{name | upper}}: {{full_path_struct}} = {{full_path_struct}}{ptr:{{p.base_addr[0] | to_hex }}u32 as _};
 {% else %}
-pub const {{name | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [{%- for addr in p.base_addr %}  {{full_path_struct}}({{addr | to_hex }}u32 as _), {% endfor -%}];
+pub const {{name | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [{%- for addr in p.base_addr %}  {{full_path_struct}}{ptr:{{addr | to_hex }}u32 as _}, {% endfor -%}];
 {%- endif -%}
 {%- endfor -%} {# for name,p in ir.device.peripheral_mod #}
 {% if ir_csfr %}
@@ -60,9 +60,9 @@ pub const {{name | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [
 {%- set module_name = p.name | to_mod_id -%}
 {% if not loop.last %}feature = "{{module_name}}",{% else %}feature = "{{module_name}}"))]
 {%- if p.base_addr | length == 1 %}
-pub const {{"csfr_cpu" | upper}}: {{full_path_struct}} = {{full_path_struct}}({{p.base_addr[0] | to_hex }}u32 as _);
+pub const {{"csfr_cpu" | upper}}: {{full_path_struct}} = {{full_path_struct}}{ptr:{{p.base_addr[0] | to_hex }}u32 as _};
 {% else %}
-pub const {{"csfr_cpu" | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [{%- for addr in p.base_addr %}  {{full_path_struct}}({{addr | to_hex }}u32 as _), {% endfor -%}];
+pub const {{"csfr_cpu" | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [{%- for addr in p.base_addr %}  {{full_path_struct}}{ptr:{{addr | to_hex }}u32 as _}, {% endfor -%}];
 {% endif %}
 {% endif %}
 {%- endfor -%}

--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -21,13 +21,13 @@ Unsupported register size
 #[inline(always)]
 {% if reg.dim == 1 -%}
 pub const fn {{reg.name | to_func_id }}(&self) -> crate::common::Reg<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}> {
-    unsafe { crate::common::Reg::from_ptr(self.0.add({{reg.offset}}usize)) }
+    unsafe { crate::common::Reg::from_ptr(self.ptr.add({{reg.offset}}usize)) }
 }
 {%- else -%}
 pub const fn {{reg.name | to_func_id }}(&self) -> [crate::common::Reg<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}>;{{reg.dim}}] {
     unsafe {  [
     {%- for index in range(end=reg.dim) -%}
-    crate::common::Reg::from_ptr(self.0.add({{reg.offset | to_hex }}usize + {{index * reg.dim_increment | to_hex }}usize )),
+    crate::common::Reg::from_ptr(self.ptr.add({{reg.offset | to_hex }}usize + {{index * reg.dim_increment | to_hex }}usize )),
     {% endfor -%}
     ] }
 }
@@ -143,13 +143,13 @@ pub mod {{reg_mod_name}} {
 #[inline(always)]
 {%- if cluster.dim == 1 %}
 pub fn {{cluster_func}}(self) -> {{cluster_struct_path}}{
-    unsafe {   {{cluster_struct_path}}(self.0.add({{cluster.offset}}usize)) }
+    unsafe {   {{cluster_struct_path}}{ptr:self.ptr.add({{cluster.offset}}usize)} }
 }
 {%- else %}
 pub fn {{cluster_func}}(self) -> [{{cluster_struct_path}};{{cluster.dim}}] {
     unsafe {  [
         {%- for index in range(end=cluster.dim) -%}
-        {{cluster_struct_path}}(self.0.add({{cluster.offset | to_hex}}usize + {{index*cluster.dim_increment | to_hex }}usize)),
+        {{cluster_struct_path}}{ptr:self.ptr.add({{cluster.offset | to_hex}}usize + {{index*cluster.dim_increment | to_hex }}usize)},
         {% endfor -%}
         ] }
 }
@@ -163,7 +163,7 @@ pub fn {{cluster_func}}(self) -> [{{cluster_struct_path}};{{cluster.dim}}] {
 {%- set cluster_mod = cluster.struct_id | to_mod_id -%}
 #[doc = "{{cluster.description | svd_description_to_doc}}"]
 #[derive(Copy, Clone, Eq, PartialEq)]
-pub struct {{ cluster_struct }}(pub(crate) *mut u8);
+pub struct {{ cluster_struct }}{pub(crate) ptr: *mut u8}
 unsafe impl ::core::marker::Send for {{ cluster_struct}} {}
 unsafe impl ::core::marker::Sync for {{ cluster_struct }} {}
 impl {{cluster_struct}} {

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -924,6 +924,33 @@
 				</cluster>
 			</registers>
 		</peripheral>
+		<peripheral>
+			<name>P33</name>
+			<description>Port naming peripheral struct and peripheral const are the same</description>
+			<baseAddress>0x70100000</baseAddress>
+			<access>read-write</access>
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x2000</size>
+				<usage>registers</usage>
+			</addressBlock>
+			<registers>
+				<cluster>
+					<name>I2C2</name>
+					<description>Cluster that defines the base type</description>
+					<headerStructName/>
+					<addressOffset>0x0</addressOffset>
+					<register>
+						<name>Reg1</name>
+						<addressOffset>0x00</addressOffset>
+					</register>
+					<register>
+						<name>Reg2</name>
+						<addressOffset>0x4</addressOffset>
+					</register>
+				</cluster>
+			</registers>
+		</peripheral>
 	</peripherals>
 	<vendorExtensions>
 		<aurixCSFR>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Fixed bug #15 