### PR TITLE
Feature/unroll csfr clusters

### DIFF
--- a/templates/rust/aurix_core.tera
+++ b/templates/rust/aurix_core.tera
@@ -10,25 +10,27 @@ use crate::common::{*};
 #[allow(unused_imports)]
 use crate::common::sealed;
 #[doc = r"{{peri.description | svd_description_to_doc}}"]
-#[derive(Copy, Clone, Eq, PartialEq)]
 {% set peri_struct = "CsfrCpu" | to_struct_id -%}
-{% set reg_base_addr = peri.base_addr[0]  -%}
-pub struct {{ peri_struct }}{pub(super) ptr: *mut u8}
-unsafe impl core::marker::Send for CsfrCpu  {}
-unsafe impl core::marker::Sync for CsfrCpu  {}
-impl CsfrCpu {
+{% set peri_base_addr = peri.base_addr[0]  -%}
+unsafe impl core::marker::Send for super::CsfrCpu  {}
+unsafe impl core::marker::Sync for super::CsfrCpu  {}
+impl super::CsfrCpu {
 {%- for register_name,reg in peri.registers %}
-{{macros::register_core_func(types_mod="self",reg=reg, base_addr=reg_base_addr)}}
+{{macros::register_core_func(types_mod="self",reg=reg, base_addr=peri_base_addr)}}
 {% endfor -%}
 {% for cluster_name,cluster in peri.clusters -%}
-{{macros::cluster_func(types_mod="self",cluster=cluster)}}
+{{macros::cluster_func_csfr(types_mod="self",cluster=cluster, base_addr=peri_base_addr)}}
 {% endfor %}
+
 }
 {% for register_name,reg in peri.registers -%}
-{{macros::register_struct(reg=reg)}}
+{{macros::register_struct(reg_name=reg.name,reg=reg)}}
 {% endfor %}
 {% for cluster_name,cluster in peri.clusters -%}
-{{macros::cluster_struct(cluster=cluster)}}
+{% for register_name,reg in cluster.registers -%}
+{% set cluster_reg_name = cluster.name~"_"~reg.name  -%}
+{{macros::register_struct(reg_name=cluster_reg_name,reg=reg)}}
+{% endfor %}
 {% endfor %}
 
 

--- a/templates/rust/aurix_core.tera
+++ b/templates/rust/aurix_core.tera
@@ -1,4 +1,79 @@
 {% import "macros.tera" as macros %}
+
+{# Generated core register function #}
+{%- macro register_core_func(types_mod,reg, base_addr) -%}
+{%- set reg_struct = reg.name | to_struct_id -%}
+{%- set reg_struct_name = types_mod ~ "::" ~  reg_struct  -%}
+{%- set reg_mod_name = reg.name | to_mod_id -%}
+{%- set reg_addr = base_addr+reg.offset | to_hex -%}
+#[doc = r"{{reg.description | svd_description_to_doc}}"]
+#[inline(always)]
+{% if reg.dim == 1 -%}
+pub const fn {{reg.name | to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- else -%}
+{%- for index in range(end=reg.dim) -%}
+pub const fn {{reg.name~index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+index*reg.dim_increment | to_hex }}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{% endfor -%}
+{%- endif -%}
+{%- endmacro -%}
+
+
+{# Generated core cluster unrolled into register function #}
+{%- macro cluster_register_core_func(types_mod,reg,base_addr,cluster_index,cluster) -%}
+{%- set reg_struct = cluster.name~"_"~reg.name | to_struct_id -%}
+{%- set reg_struct_name = types_mod ~ "::" ~  reg_struct  -%}
+{%- set reg_addr = base_addr+reg.offset | to_hex -%}
+#[doc = r"{{reg.description | svd_description_to_doc}}"]
+#[inline(always)]
+{% if reg.dim == 1 -%}
+{% if cluster.dim == 1 -%}
+pub const fn {{cluster.name~"_"~reg.name| to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- else -%}
+pub const fn {{cluster.name~"_"~reg.name~cluster_index| to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- endif -%}
+{%- else -%}
+{%- for reg_index in range(end=reg.dim) -%}
+{% if cluster.dim == 1 -%}
+pub const fn {{cluster.name~"_"~reg.name~reg_index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+reg_index*reg.dim_increment | to_hex }}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- else -%}
+pub const fn {{cluster.name~"_"~reg.name~"_"~cluster_index~"_"~reg_index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+reg_index*reg.dim_increment | to_hex }}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- endif -%}
+{% endfor -%}
+{%- endif -%}
+{%- endmacro -%}
+
+{# Unroll the cluster register for aurix csfr #}
+{%- macro cluster_func_csfr(types_mod,cluster, base_addr) -%}
+{%- set cluster_struct_id = cluster.name | to_struct_id -%}
+{%- set cluster_base_addr = base_addr+cluster.offset -%}
+#[doc = "{{cluster.description | svd_description_to_doc}}"]
+#[inline(always)]
+{%- if cluster.dim == 1 %}
+{% for register_name,reg in cluster.registers -%}
+{{self::cluster_register_core_func(types_mod="self",reg=reg, base_addr=cluster_base_addr,cluster_index=0,cluster=cluster)}}
+{% endfor -%}
+{%- else %}
+{%- for index in range(end=cluster.dim) -%}
+{%- set current_cluster_addr = cluster_base_addr+index*cluster.dim_increment -%}
+{% for register_name,reg in cluster.registers -%}
+{{self::cluster_register_core_func(types_mod="self",reg=reg, base_addr=current_cluster_addr,cluster_index=index,cluster=cluster)}}
+{% endfor -%}
+{% endfor -%}
+{%- endif -%}
+{%- endmacro -%}
+
 /*
 {{ir.license_text}}
 */
@@ -16,20 +91,20 @@ unsafe impl core::marker::Send for super::CsfrCpu  {}
 unsafe impl core::marker::Sync for super::CsfrCpu  {}
 impl super::CsfrCpu {
 {%- for register_name,reg in peri.registers %}
-{{macros::register_core_func(types_mod="self",reg=reg, base_addr=peri_base_addr)}}
+{{self::register_core_func(types_mod="self",reg=reg, base_addr=peri_base_addr)}}
 {% endfor -%}
 {% for cluster_name,cluster in peri.clusters -%}
-{{macros::cluster_func_csfr(types_mod="self",cluster=cluster, base_addr=peri_base_addr)}}
+{{self::cluster_func_csfr(types_mod="self",cluster=cluster, base_addr=peri_base_addr)}}
 {% endfor %}
 
 }
 {% for register_name,reg in peri.registers -%}
-{{macros::register_struct(reg_name=reg.name,reg=reg)}}
+{{macros::register_struct(reg=reg)}}
 {% endfor %}
 {% for cluster_name,cluster in peri.clusters -%}
 {% for register_name,reg in cluster.registers -%}
 {% set cluster_reg_name = cluster.name~"_"~reg.name  -%}
-{{macros::register_struct(reg_name=cluster_reg_name,reg=reg)}}
+{{macros::register_struct(reg=reg,reg_name=cluster_reg_name)}}
 {% endfor %}
 {% endfor %}
 

--- a/templates/rust/lib.tera
+++ b/templates/rust/lib.tera
@@ -56,7 +56,17 @@ pub const {{name | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [
 {% if ir_csfr %}
 #[cfg(any(
 {%- set module_struct = "csfr_cpu" | to_struct_id -%}
-{%- set full_path_struct = "csfr_cpu" ~ "::" ~ module_struct -%}
+{%- set full_path_struct = "self::" ~ module_struct -%}
+{% for name,p in ir_csfr.device.peripheral_mod %}
+{%- set module_name = p.name | to_mod_id -%}
+{% if not loop.last %}feature = "{{module_name}}",{% else %}feature = "{{module_name}}"))]
+#[derive(Copy, Clone, Eq, PartialEq)] 
+pub struct {{ module_struct }}{ptr:*mut u8}
+{% endif %}
+{%- endfor -%}
+#[cfg(any(
+{%- set module_struct = "csfr_cpu" | to_struct_id -%}
+{%- set full_path_struct = "self::" ~ module_struct -%}
 {% for name,p in ir_csfr.device.peripheral_mod %}
 {%- set module_name = p.name | to_mod_id -%}
 {% if not loop.last %}feature = "{{module_name}}",{% else %}feature = "{{module_name}}"))]

--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -57,6 +57,39 @@ pub const fn {{reg.name~index| to_func_id }}(&self)-> crate::common::RegCore<{{r
 {%- endmacro -%}
 
 
+{# Generated core cluster unrolled into register function #}
+{%- macro cluster_register_core_func(types_mod,reg,base_addr,cluster_index,cluster) -%}
+{%- set reg_struct = cluster.name~"_"~reg.name | to_struct_id -%}
+{%- set reg_struct_name = types_mod ~ "::" ~  reg_struct  -%}
+{%- set reg_addr = base_addr+reg.offset | to_hex -%}
+#[doc = r"{{reg.description | svd_description_to_doc}}"]
+#[inline(always)]
+{% if reg.dim == 1 -%}
+{% if cluster.dim == 1 -%}
+pub const fn {{cluster.name~"_"~reg.name| to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- else -%}
+pub const fn {{cluster.name~"_"~reg.name~cluster_index| to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- endif -%}
+{%- else -%}
+{%- for reg_index in range(end=reg.dim) -%}
+{% if cluster.dim == 1 -%}
+pub const fn {{cluster.name~"_"~reg.name~reg_index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+reg_index*reg.dim_increment | to_hex }}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- else -%}
+pub const fn {{cluster.name~"_"~reg.name~"_"~cluster_index~"_"~reg_index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+reg_index*reg.dim_increment | to_hex }}> {
+    unsafe { crate::common::RegCore::new() }
+}
+{%- endif -%}
+{% endfor -%}
+{%- endif -%}
+{%- endmacro -%}
+
+
 {%- macro bitfield_type(field,reg_struct_name,reg_mod_name,turbofish) -%}
 {%-if turbofish %}{%set separator = "::"%}{%else%}{%set separator = ""%}{%endif-%}
 {%- if not field.enum_type and field.mask == 1 %}
@@ -73,9 +106,10 @@ pub const fn {{reg.name~index| to_func_id }}(&self)-> crate::common::RegCore<{{r
 {%- endmacro -%}
 
 
-{%- macro register_struct(reg) -%}
-{%- set reg_struct_name = reg.name | to_struct_id -%}
-{%- set reg_mod_name = reg.name | to_mod_id -%}
+{%- macro register_struct(reg_name,reg) -%}
+{%- set reg_struct_name = reg_name | to_struct_id -%}
+{%- set reg_mod_name = reg_name | to_mod_id -%}
+
 
 #[doc(hidden)]
 #[derive(Copy, Clone,Eq, PartialEq)]
@@ -156,6 +190,7 @@ pub fn {{cluster_func}}(self) -> [{{cluster_struct_path}};{{cluster.dim}}] {
 {%- endif -%}
 {%- endmacro -%}
 
+
 {# Macro to generate structure and module for a cluster#}
 {%- macro cluster_struct(cluster) -%}
 {%- if not cluster.is_derived_from -%}
@@ -178,11 +213,32 @@ pub mod {{cluster_mod}} {
     #[allow(unused_imports)]
     use crate::common::{*};
     {% for register_name,reg in cluster.registers -%}
-    {{self::register_struct(reg=reg)}}
+    {{self::register_struct(reg_name=reg.name,reg=reg)}}
     {% endfor -%}
     {% for cluster_name,cluster in cluster.clusters -%}
     {{self::cluster_struct(cluster=cluster) }}
     {% endfor -%}
 }
 {%- endif -%} {# if not cluster.is_derived_from #}
+{%- endmacro -%}
+
+
+{# Unroll the cluster register for aurix csfr #}
+{%- macro cluster_func_csfr(types_mod,cluster, base_addr) -%}
+{%- set cluster_struct_id = cluster.name | to_struct_id -%}
+{%- set cluster_base_addr = base_addr+cluster.offset -%}
+#[doc = "{{cluster.description | svd_description_to_doc}}"]
+#[inline(always)]
+{%- if cluster.dim == 1 %}
+{% for register_name,reg in cluster.registers -%}
+{{self::cluster_register_core_func(types_mod="self",reg=reg, base_addr=cluster_base_addr,cluster_index=0,cluster=cluster)}}
+{% endfor -%}
+{%- else %}
+{%- for index in range(end=cluster.dim) -%}
+{%- set current_cluster_addr = cluster_base_addr+index*cluster.dim_increment -%}
+{% for register_name,reg in cluster.registers -%}
+{{self::cluster_register_core_func(types_mod="self",reg=reg, base_addr=current_cluster_addr,cluster_index=index,cluster=cluster)}}
+{% endfor -%}
+{% endfor -%}
+{%- endif -%}
 {%- endmacro -%}

--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -34,62 +34,6 @@ pub const fn {{reg.name | to_func_id }}(&self) -> [crate::common::Reg<{{reg_stru
 {%- endif -%}
 {%- endmacro -%}
  
-
-{# Generated core register function #}
-{%- macro register_core_func(types_mod,reg, base_addr) -%}
-{%- set reg_struct = reg.name | to_struct_id -%}
-{%- set reg_struct_name = types_mod ~ "::" ~  reg_struct  -%}
-{%- set reg_mod_name = reg.name | to_mod_id -%}
-{%- set reg_addr = base_addr+reg.offset | to_hex -%}
-#[doc = r"{{reg.description | svd_description_to_doc}}"]
-#[inline(always)]
-{% if reg.dim == 1 -%}
-pub const fn {{reg.name | to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
-    unsafe { crate::common::RegCore::new() }
-}
-{%- else -%}
-{%- for index in range(end=reg.dim) -%}
-pub const fn {{reg.name~index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+index*reg.dim_increment | to_hex }}> {
-    unsafe { crate::common::RegCore::new() }
-}
-{% endfor -%}
-{%- endif -%}
-{%- endmacro -%}
-
-
-{# Generated core cluster unrolled into register function #}
-{%- macro cluster_register_core_func(types_mod,reg,base_addr,cluster_index,cluster) -%}
-{%- set reg_struct = cluster.name~"_"~reg.name | to_struct_id -%}
-{%- set reg_struct_name = types_mod ~ "::" ~  reg_struct  -%}
-{%- set reg_addr = base_addr+reg.offset | to_hex -%}
-#[doc = r"{{reg.description | svd_description_to_doc}}"]
-#[inline(always)]
-{% if reg.dim == 1 -%}
-{% if cluster.dim == 1 -%}
-pub const fn {{cluster.name~"_"~reg.name| to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
-    unsafe { crate::common::RegCore::new() }
-}
-{%- else -%}
-pub const fn {{cluster.name~"_"~reg.name~cluster_index| to_func_id }}(&self) -> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{reg_addr}}> {
-    unsafe { crate::common::RegCore::new() }
-}
-{%- endif -%}
-{%- else -%}
-{%- for reg_index in range(end=reg.dim) -%}
-{% if cluster.dim == 1 -%}
-pub const fn {{cluster.name~"_"~reg.name~reg_index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+reg_index*reg.dim_increment | to_hex }}> {
-    unsafe { crate::common::RegCore::new() }
-}
-{%- else -%}
-pub const fn {{cluster.name~"_"~reg.name~"_"~cluster_index~"_"~reg_index| to_func_id }}(&self)-> crate::common::RegCore<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}, {{base_addr+reg.offset+reg_index*reg.dim_increment | to_hex }}> {
-    unsafe { crate::common::RegCore::new() }
-}
-{%- endif -%}
-{% endfor -%}
-{%- endif -%}
-{%- endmacro -%}
-
-
 {%- macro bitfield_type(field,reg_struct_name,reg_mod_name,turbofish) -%}
 {%-if turbofish %}{%set separator = "::"%}{%else%}{%set separator = ""%}{%endif-%}
 {%- if not field.enum_type and field.mask == 1 %}
@@ -106,10 +50,14 @@ pub const fn {{cluster.name~"_"~reg.name~"_"~cluster_index~"_"~reg_index| to_fun
 {%- endmacro -%}
 
 
-{%- macro register_struct(reg_name,reg) -%}
+{%- macro register_struct(reg,reg_name="") -%}
+{%-if reg_name %}
 {%- set reg_struct_name = reg_name | to_struct_id -%}
 {%- set reg_mod_name = reg_name | to_mod_id -%}
-
+{%- else -%}
+{%- set reg_struct_name = reg.name | to_struct_id -%}
+{%- set reg_mod_name = reg.name | to_mod_id -%}
+{%- endif -%}
 
 #[doc(hidden)]
 #[derive(Copy, Clone,Eq, PartialEq)]
@@ -213,7 +161,7 @@ pub mod {{cluster_mod}} {
     #[allow(unused_imports)]
     use crate::common::{*};
     {% for register_name,reg in cluster.registers -%}
-    {{self::register_struct(reg_name=reg.name,reg=reg)}}
+    {{self::register_struct(reg=reg)}}
     {% endfor -%}
     {% for cluster_name,cluster in cluster.clusters -%}
     {{self::cluster_struct(cluster=cluster) }}
@@ -223,22 +171,3 @@ pub mod {{cluster_mod}} {
 {%- endmacro -%}
 
 
-{# Unroll the cluster register for aurix csfr #}
-{%- macro cluster_func_csfr(types_mod,cluster, base_addr) -%}
-{%- set cluster_struct_id = cluster.name | to_struct_id -%}
-{%- set cluster_base_addr = base_addr+cluster.offset -%}
-#[doc = "{{cluster.description | svd_description_to_doc}}"]
-#[inline(always)]
-{%- if cluster.dim == 1 %}
-{% for register_name,reg in cluster.registers -%}
-{{self::cluster_register_core_func(types_mod="self",reg=reg, base_addr=cluster_base_addr,cluster_index=0,cluster=cluster)}}
-{% endfor -%}
-{%- else %}
-{%- for index in range(end=cluster.dim) -%}
-{%- set current_cluster_addr = cluster_base_addr+index*cluster.dim_increment -%}
-{% for register_name,reg in cluster.registers -%}
-{{self::cluster_register_core_func(types_mod="self",reg=reg, base_addr=current_cluster_addr,cluster_index=index,cluster=cluster)}}
-{% endfor -%}
-{% endfor -%}
-{%- endif -%}
-{%- endmacro -%}

--- a/templates/rust/peri_mod.tera
+++ b/templates/rust/peri_mod.tera
@@ -22,7 +22,7 @@ impl super::{{ peri_struct }} {
 {% endfor %}
 }
 {% for register_name,reg in peri.registers -%}
-{{macros::register_struct(reg=reg)}}
+{{macros::register_struct(reg_name=reg.name,reg=reg)}}
 {% endfor %}
 {% for cluster_name,cluster in peri.clusters -%}
 {{macros::cluster_struct(cluster=cluster)}}

--- a/templates/rust/peri_mod.tera
+++ b/templates/rust/peri_mod.tera
@@ -22,7 +22,7 @@ impl super::{{ peri_struct }} {
 {% endfor %}
 }
 {% for register_name,reg in peri.registers -%}
-{{macros::register_struct(reg_name=reg.name,reg=reg)}}
+{{macros::register_struct(reg=reg)}}
 {% endfor %}
 {% for cluster_name,cluster in peri.clusters -%}
 {{macros::cluster_struct(cluster=cluster)}}


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

Support unroll of clusters for csfr peripherals
The cluster name has been prefixed because there are clusters with register of same name, without the prefixing it would result in compilation errors E.g The Clusters TPS and FPU_TRAP have the register with the name CON.
Naming-Index convention followed:
If Cluster has dim=1, reg has dim=1 then {clustername}\_\{regname} E.g tps_extim_exit_cval  for EXIT_CVAL register of TPS_EXTIM Cluster
If Cluster has dim>1, reg has dim=1 then {clustername}\_\{regname}{clusterindex}E.g cpr_cpry_u0  for  CPRy_U register of CPR[%s] Cluster
If Cluster has dim=1, reg has dim>1 then  {clustername}\_\{regname}{regindex} E.g tps_timer0 for TIMER[%s] register of TPS Cluster
If Cluster has dim>1, reg has dim>1 then  {clustername}\_\{regname}\_\{clusterindex}\_\{regindex} (This condition not there currently for any of the clusters in the tricore svd)


