### PR TITLE
35 compilation fail when in svd file is used headerstructname in cluster declaration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -881,7 +881,7 @@ dependencies = [
 
 [[package]]
 name = "svd2pac"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "svd2pac"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.70"
 categories = ["command-line-utilities", "development-tools::ffi"]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tool to generate Peripheral Access Crates from SVD files
 
 This tool has a very different approach compared to `svd2rust` because our requirements are different and are quite similar to [chiptool](https://github.com/embassy-rs/chiptool).
 
-### Major Requirements
+## Major Requirements
 
 - Register access should be unsafe because we consider akin to C FFI.
   Inherent undefined behavior should be dealt with at the driver layers, trying to handle safety in the PAC often does either not help or make it hard to use.
@@ -18,13 +18,14 @@ This tool has a very different approach compared to `svd2rust` because our requi
   external libraries. This allows the execution unit tests for code that uses the generated libraries on non-embedded devices.
 - No macros. Absence of macros make easier the debugging.
 - PAC shall have 0 dependencies to any other crates.
-   - Exception: `--target=cortex-m`. In this case the generated PAC has some dependencies in order to be usable in ARM Cortex Rust ecosystem.
+  - Exception: `--target=cortex-m`. In this case the generated PAC has some dependencies in order to be usable in ARM Cortex Rust ecosystem.
 - Use associated constants instead of `Enum` for bitfield values so users can easily create new values.
   Enumerations constrain the possible values of a bitfield but many times the SVD enum description has missing enumeration values.
   There are multiple reasons:
-    * Too many values for documentation/SVD.
-    * Valid values depend on other register values or conditions so documentation writers could decided to not list them in the SVD.
-    * Lazyness of user manual writer. (Sorry but it sometimes happens ;-))
+
+- Too many values for documentation/SVD.
+  - Valid values depend on other register values or conditions so documentation writers could decided to not list them in the SVD.
+  - Lazyness of user manual writer. (Sorry but it sometimes happens ;-))
 
 ## Known Limitations
 
@@ -193,12 +194,13 @@ unsafe {
     })
 }
 ```
-> Note: The register is not modified when the `set()` function is called. `set()` modifies the value
-        stored in the CPU and returns the modified struct. The register is only written once with
-        the value returned by the closure.
 
+> Note: The register is not modified when the `set()` function is called. `set()` modifies the value
+> stored in the CPU and returns the modified struct. The register is only written once with
+> the value returned by the closure.
+>
 > Note: `modify()`, due to doing a read and write with modification of read data in between is not
-        atomic and can be subject to race conditions and may be interrupted by an interrupt.
+> atomic and can be subject to race conditions and may be interrupted by an interrupt.
 
 #### Write
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This tool has a very different approach compared to `svd2rust` because our requi
 * `readAction` tag is ignored
 * `headerEnumName` tag is ignored
 * in `enumeratedValue` only `value` tag is supported. No support for _don't care bits_ and `isDefault` tag
+* `alternateGroup` is ignored therefore it is not possible to have two registers with same name.
 
 ## How to install & prerequisite
 

--- a/src/rust_gen/ir.rs
+++ b/src/rust_gen/ir.rs
@@ -140,7 +140,7 @@ pub struct Cluster {
     /// Id of the struct
     pub struct_id: String,
     /// Id of module containing nested cluster
-    pub module_id:String
+    pub module_id: String,
 }
 
 /// Describe Rust module that maps to a peripheral

--- a/src/rust_gen/ir.rs
+++ b/src/rust_gen/ir.rs
@@ -139,6 +139,8 @@ pub struct Cluster {
     pub struct_module_path: Vec<String>,
     /// Id of the struct
     pub struct_id: String,
+    /// Id of module containing nested cluster
+    pub module_id:String
 }
 
 /// Describe Rust module that maps to a peripheral

--- a/src/svd_util.rs
+++ b/src/svd_util.rs
@@ -1,6 +1,6 @@
-use svd_parser::svd;
+use svd_parser::svd::{self};
 
-pub trait ExpandedName: svd_parser::svd::Name {
+pub(crate) trait ExpandedName: svd_parser::svd::Name {
     /// Generate an identifier that can be used in derivedFrom tags
     /// CMSIS svd.xsd specification is not consisted with svdconv.exe.
     /// In xsd file derivedFrom is of type dimableIdentifierType and
@@ -47,5 +47,29 @@ impl ExpandedName for svd::Peripheral {
                 .name
                 .to_string(),
         }
+    }
+}
+
+/// Trait to ger headerStructName field
+pub(crate) trait HeaderStructName {
+    fn header_struct_name(&self)->Option<String>;
+}
+
+impl HeaderStructName for svd::Peripheral {
+    fn header_struct_name(&self)->Option<String> {
+        self.header_struct_name.clone()
+    }
+}
+
+impl HeaderStructName for svd::Cluster {
+    fn header_struct_name(&self)->Option<String> {
+        self.header_struct_name.clone()
+    }
+}
+
+impl HeaderStructName for svd::Register {
+    fn header_struct_name(&self)->Option<String> {
+        None
+        
     }
 }

--- a/src/svd_util.rs
+++ b/src/svd_util.rs
@@ -52,24 +52,23 @@ impl ExpandedName for svd::Peripheral {
 
 /// Trait to ger headerStructName field
 pub(crate) trait HeaderStructName {
-    fn header_struct_name(&self)->Option<String>;
+    fn header_struct_name(&self) -> Option<String>;
 }
 
 impl HeaderStructName for svd::Peripheral {
-    fn header_struct_name(&self)->Option<String> {
+    fn header_struct_name(&self) -> Option<String> {
         self.header_struct_name.clone()
     }
 }
 
 impl HeaderStructName for svd::Cluster {
-    fn header_struct_name(&self)->Option<String> {
+    fn header_struct_name(&self) -> Option<String> {
         self.header_struct_name.clone()
     }
 }
 
 impl HeaderStructName for svd::Register {
-    fn header_struct_name(&self)->Option<String> {
+    fn header_struct_name(&self) -> Option<String> {
         None
-        
     }
 }

--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -143,7 +143,7 @@ pub fn {{cluster_func}}(self) -> [{{cluster_struct_path}};{{cluster.dim}}] {
 {%- macro cluster_struct(cluster) -%}
 {%- if not cluster.is_derived_from -%}
 {%- set cluster_struct = cluster.struct_id | to_struct_id -%}
-{%- set cluster_mod = cluster.struct_id | to_mod_id -%}
+{%- set cluster_mod = cluster.module_id -%}
 #[doc = "{{cluster.description | svd_description_to_doc}}"]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct {{ cluster_struct }}{pub(crate) ptr: *mut u8}

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- edited with XMLSpy v2024 rel. 2 (x64) (https://www.altova.com) by Infineon Technologies AG (Infineon Technologies AG) -->
 <!-- File naming: <part/series name>.svd -->
 <!--
   Copyright (C) 2012-2014 ARM Limited. All rights reserved.
@@ -527,6 +528,31 @@
 							<resetValue>0x12345</resetValue>
 						</register>
 					</cluster>
+					<cluster>
+						<dim>1</dim>
+						<dimIncrement>16</dimIncrement>
+						<name>HSSL[%s]</name>
+						<description>HSSL</description>
+						<headerStructName>HSSL_HSSL</headerStructName>
+						<addressOffset>0x200</addressOffset>
+						<cluster>
+							<dim>2</dim>
+							<dimIncrement>4</dimIncrement>
+							<name>CH[%s]</name>
+							<description>CH</description>
+							<headerStructName>HSSL_HSSL_CH</headerStructName>
+							<addressOffset>0x0</addressOffset>
+							<register>
+								<name>HSSLxCOKy</name>
+								<description>HSSL0 Channel 0 OK Service Request
+ resetvalue={Application Reset:0x0}</description>
+								<addressOffset>0x0</addressOffset>
+								<size>32</size>
+								<resetValue>0x0</resetValue>
+								<resetMask>0x0FFFFFFFF</resetMask>
+							</register>
+						</cluster>
+					</cluster>
 					<register>
 						<name>CR</name>
 						<addressOffset>0x00</addressOffset>
@@ -559,7 +585,7 @@
 					<dimIncrement>0x100</dimIncrement>
 					<name>ClusterDim[%s]</name>
 					<description>Test Cluster array </description>
-					<addressOffset>0x200</addressOffset>
+					<addressOffset>0x1000</addressOffset>
 					<register>
 						<name>CR</name>
 						<addressOffset>0x00</addressOffset>


### PR DESCRIPTION
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---

CONTRIBUTING.md also tells you what to expect in the PR process.

Description
Cluster module name is derived from headerStructName if present otherwise cluster name is used.
Previously the name of module was derived from struct name and not directly from headerStructName.
If the name contains underscore this was lost in conversion. In fact underscore is allowed in module names but not in struct name.
e.g. hsl_hsl (cluster name) --> hslhsl(struct name) --> hslhsl (module name)
Now the module name is derived directly from cluster name
hsl_hsl(cluster name) --> hsl_hsl(module name)

Related Issue
#35 

