### PR TITLE
Fully-qualify references to ::core module in generated code

### DIFF
--- a/templates/rust/aurix_core.tera
+++ b/templates/rust/aurix_core.tera
@@ -89,8 +89,8 @@ use crate::common::sealed;
 #[doc = r"{{peri.description | svd_description_to_doc}}"]
 {% set peri_struct = "CsfrCpu" | to_struct_id -%}
 {% set peri_base_addr = peri.base_addr[0]  -%}
-unsafe impl core::marker::Send for super::CsfrCpu  {}
-unsafe impl core::marker::Sync for super::CsfrCpu  {}
+unsafe impl ::core::marker::Send for super::CsfrCpu  {}
+unsafe impl ::core::marker::Sync for super::CsfrCpu  {}
 impl super::CsfrCpu {
 {%- for register_name,reg in peri.registers %}
 {{self::register_core_func(types_mod="self",reg=reg, base_addr=peri_base_addr)}}

--- a/templates/rust/peri_mod.tera
+++ b/templates/rust/peri_mod.tera
@@ -13,8 +13,8 @@ use crate::common::{*};
 use crate::common::sealed;
 #[doc = r"{{peri.description | svd_description_to_doc}}"]
 {% set peri_struct = peri.name | to_struct_id -%}
-unsafe impl core::marker::Send for super::{{ peri_struct }} {}
-unsafe impl core::marker::Sync for super::{{ peri_struct }} {}
+unsafe impl ::core::marker::Send for super::{{ peri_struct }} {}
+unsafe impl ::core::marker::Sync for super::{{ peri_struct }} {}
 impl super::{{ peri_struct }} {
 {%- for register_name,reg in peri.registers %}
 {{macros::register_func(types_mod="self",reg=reg)}}


### PR DESCRIPTION
If the SVD file declares an item called `core`, then references to
items from the core library like `core::marker::Send` fail to compile
because `core` is shadowed. Fully-qualify `::core` to resolve this.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
