### PR TITLE
Consistently use headerStructName for peripherals' module and structure identifiers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -758,6 +758,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustix"
 version = "0.38.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -784,6 +793,12 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
@@ -892,6 +907,7 @@ dependencies = [
  "lazy-regex",
  "linked-hash-map",
  "log",
+ "rustc_version",
  "serde",
  "serde_json",
  "similar",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,11 +10,6 @@ keywords = ["generator","svd", "pac"]
 license = "MIT"
 description = "Tool to generate peripheral access crates from SVD files"
 
-[features]
-# Set this feature to execute test for Aurix Hightect compiler
-# it shall be not used 
-aurix_tests=[]
-
 [dependencies]
 anyhow = "1.0.70"
 lazy-regex = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,11 @@ keywords = ["generator","svd", "pac"]
 license = "MIT"
 description = "Tool to generate peripheral access crates from SVD files"
 
+[features]
+# Set this feature to execute test for Aurix Hightect compiler
+# it shall be not used 
+aurix_tests=[]
+
 [dependencies]
 anyhow = "1.0.70"
 lazy-regex = "3.0"
@@ -32,6 +37,9 @@ similar = "2.2"
 fs_extra = "1.3"
 tempfile = "3.6"
 toml_edit = "0.19"
+
+[build-dependencies]
+rustc_version = "0.4.1"
 
 [profile.dev.package."*"]
 codegen-units = 1 # better optimizations

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Tool to generate Peripheral Access Crates from SVD files
 
 This tool has a very different approach compared to `svd2rust` because our requirements are different and are quite similar to [chiptool](https://github.com/embassy-rs/chiptool).
 
-### Major Requirements
+## Major Requirements
 
 - Register access should be unsafe because we consider akin to C FFI.
   Inherent undefined behavior should be dealt with at the driver layers, trying to handle safety in the PAC often does either not help or make it hard to use.
@@ -18,13 +18,14 @@ This tool has a very different approach compared to `svd2rust` because our requi
   external libraries. This allows the execution unit tests for code that uses the generated libraries on non-embedded devices.
 - No macros. Absence of macros make easier the debugging.
 - PAC shall have 0 dependencies to any other crates.
-   - Exception: `--target=cortex-m`. In this case the generated PAC has some dependencies in order to be usable in ARM Cortex Rust ecosystem.
+  - Exception: `--target=cortex-m`. In this case the generated PAC has some dependencies in order to be usable in ARM Cortex Rust ecosystem.
 - Use associated constants instead of `Enum` for bitfield values so users can easily create new values.
   Enumerations constrain the possible values of a bitfield but many times the SVD enum description has missing enumeration values.
   There are multiple reasons:
-    * Too many values for documentation/SVD.
-    * Valid values depend on other register values or conditions so documentation writers could decided to not list them in the SVD.
-    * Lazyness of user manual writer. (Sorry but it sometimes happens ;-))
+
+- Too many values for documentation/SVD.
+  - Valid values depend on other register values or conditions so documentation writers could decided to not list them in the SVD.
+  - Lazyness of user manual writer. (Sorry but it sometimes happens ;-))
 
 ## Known Limitations
 
@@ -193,12 +194,13 @@ unsafe {
     })
 }
 ```
-> Note: The register is not modified when the `set()` function is called. `set()` modifies the value
-        stored in the CPU and returns the modified struct. The register is only written once with
-        the value returned by the closure.
 
+> Note: The register is not modified when the `set()` function is called. `set()` modifies the value
+> stored in the CPU and returns the modified struct. The register is only written once with
+> the value returned by the closure.
+>
 > Note: `modify()`, due to doing a read and write with modification of read data in between is not
-        atomic and can be subject to race conditions and may be interrupted by an interrupt.
+> atomic and can be subject to race conditions and may be interrupted by an interrupt.
 
 #### Write
 

--- a/build.rs
+++ b/build.rs
@@ -1,6 +1,13 @@
+use rustc_version::version;
 use std::env;
 const RUSTUP_TOOLCHAIN_ID: &str = "RUSTUP_TOOLCHAIN";
 fn main() {
+    // To avoid warnings related unexpected cfgs when compiling with rustc >=1.80
+    // we want to be still compatible with Hightec Rust compiler presently supporting 1.72 version.
+    let version = version().unwrap();
+    if version.minor >= 80 {
+        println!("cargo:rustc-check-cfg=cfg(aurix_tests)");
+    }
     // In case of Aurix toolchain enable test of code generated for Aurix microcontroller
     let rustup_toolchain = env::var(RUSTUP_TOOLCHAIN_ID)
         .unwrap_or_else(|_| format!("Unable to to get environment variable {RUSTUP_TOOLCHAIN_ID}"));

--- a/src/rust_gen.rs
+++ b/src/rust_gen.rs
@@ -440,7 +440,7 @@ fn generate_peripheral_module(
     for (_, peri) in &ir.device.peripheral_mod {
         // No need to generate a module if the peripheral is derived
         let borrowed_peri = peri.borrow();
-        if borrowed_peri.is_derived_from {
+        if borrowed_peri.derived_from.is_some() {
             continue;
         }
         let module_name = borrowed_peri.module_id.clone();

--- a/src/rust_gen/ir.rs
+++ b/src/rust_gen/ir.rs
@@ -9,7 +9,10 @@ pub trait HasSameType {
 
 impl HasSameType for PeripheralMod {
     fn has_same_type(&self, other: &Self) -> bool {
-        self.clusters == other.clusters && self.registers == other.registers
+        self.clusters == other.clusters
+            && self.registers == other.registers
+            && self.struct_id == other.struct_id
+            && self.module_id == other.module_id
     }
 }
 

--- a/src/rust_gen/ir.rs
+++ b/src/rust_gen/ir.rs
@@ -155,7 +155,7 @@ pub struct PeripheralMod {
     pub registers: LinkedHashMap<String, Rc<RefCell<Register>>>,
     pub base_addr: Vec<u64>,
     pub interrupts: Vec<Interrupt>,
-    pub is_derived_from: bool,
+    pub derived_from: Option<String>,
     // Struct identifier of the peripheral.
     pub struct_id: String,
     // It could be different from name lower case if derived_from is used.

--- a/src/rust_gen/xml2ir.rs
+++ b/src/rust_gen/xml2ir.rs
@@ -149,16 +149,18 @@ impl Visitor {
         peripheral.name = svd_peripheral.name.to_internal_ident();
         peripheral.description = svd_peripheral.description.clone().unwrap_or_default();
 
+        // defined headerStructName has priority for struct ide definition.
         if let Some(header_struct) = &svd_peripheral.header_struct_name {
-            // defined headerStructName has priority for struct ide definition.
-            peripheral.struct_id = header_struct.to_sanitized_struct_ident()
-        } else if peripheral.struct_id.is_empty() {
-            // If the peripheral has no parent create Rust struct id
-            peripheral.struct_id = svd_peripheral.name.to_sanitized_struct_ident();
-        }
-
-        if peripheral.module_id.is_empty() {
-            peripheral.module_id = svd_peripheral.name.to_sanitized_mod_ident();
+            peripheral.struct_id = header_struct.to_sanitized_struct_ident();
+            peripheral.module_id = header_struct.to_sanitized_mod_ident();
+        } else {
+            // Derived peripherals inherit struct and module id from their parents.
+            if peripheral.struct_id.is_empty() {
+                peripheral.struct_id = svd_peripheral.name.to_sanitized_struct_ident();
+            }
+            if peripheral.module_id.is_empty() {
+                peripheral.module_id = svd_peripheral.name.to_sanitized_mod_ident();
+            }
         }
 
         let (dim, dim_increment) = get_dim_dim_increment(svd_peripheral);

--- a/src/rust_gen/xml2ir.rs
+++ b/src/rust_gen/xml2ir.rs
@@ -130,8 +130,15 @@ impl Visitor {
 
             let name = peripheral.name.clone();
 
-            peripheral.is_derived_from = derived_peripheral
-                .is_some_and(|derived_peri| peripheral.has_same_type(&derived_peri));
+            peripheral.derived_from = if let Some(derived_peri) = derived_peripheral {
+                if peripheral.has_same_type(&derived_peri) {
+                    Some(derived_peri.name)
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
             let peripheral_mod = Rc::new(RefCell::new(peripheral));
             self.device
                 .peripheral_mod

--- a/templates/rust/Cargo_toml.tera
+++ b/templates/rust/Cargo_toml.tera
@@ -33,14 +33,15 @@ cortex-m = "0.7.6"
 
 [features]
 {%- for peri_mod_name, peri in ir.device.peripheral_mod %}
-{{peri.name | to_mod_id}} = [{%if peri.is_derived_from %}"{{ peri.module_id }}"{% endif %}]
+{%- if peri.is_derived_from %} {% continue %} {% endif %} {# module that are derived doesn't have a module #}
+{{peri.module_id}} = []
 {%- endfor %}
 {% if ir_csfr %}
 {%- for peri_mod_name, peri in ir_csfr.device.peripheral_mod %}
-{{peri.name | to_mod_id}} = []
+{{peri.module_id}} = []
 {%- endfor %}
 {%- endif %}
-all = [{%- for peri_mod_name, peri in ir.device.peripheral_mod -%}"{{peri.name | to_mod_id }}",{%- endfor -%}]
+all = [{%- for peri_mod_name, peri in ir.device.peripheral_mod -%}"{{peri.module_id}}",{%- endfor -%}]
 {%- if tracing %}
 tracing = ["dep:phf"]
 tracing_dummy = []

--- a/templates/rust/Cargo_toml.tera
+++ b/templates/rust/Cargo_toml.tera
@@ -32,16 +32,22 @@ cortex-m = "0.7.6"
 
 
 [features]
+{%- set_global all_peripheral_features = [] -%} {# array of all features #}
 {%- for peri_mod_name, peri in ir.device.peripheral_mod %}
 {%- if peri.is_derived_from %} {% continue %} {% endif %} {# module that are derived doesn't have a module #}
-{{peri.module_id}} = []
+{%- set feature_name = peri.name | lower -%}
+{% set_global all_peripheral_features = all_peripheral_features | concat(with=feature_name) %}
+{{feature_name}} = []
 {%- endfor %}
 {% if ir_csfr %}
 {%- for peri_mod_name, peri in ir_csfr.device.peripheral_mod %}
-{{peri.module_id}} = []
+{%- set feature_name = peri.name | lower %}
+{{feature_name}} = []
 {%- endfor %}
 {%- endif %}
-all = [{%- for peri_mod_name, peri in ir.device.peripheral_mod -%}"{{peri.module_id}}",{%- endfor -%}]
+{# collect all module id and remove duplicated#}
+{%- set_global all_peripheral_features = all_peripheral_features | unique -%}
+all = ["{{all_peripheral_features | join(sep='" ,"')}}"]
 {%- if tracing %}
 tracing = ["dep:phf"]
 tracing_dummy = []

--- a/templates/rust/Cargo_toml.tera
+++ b/templates/rust/Cargo_toml.tera
@@ -34,10 +34,9 @@ cortex-m = "0.7.6"
 [features]
 {%- set_global all_peripheral_features = [] -%} {# array of all features #}
 {%- for peri_mod_name, peri in ir.device.peripheral_mod %}
-{%- if peri.is_derived_from %} {% continue %} {% endif %} {# module that are derived doesn't have a module #}
 {%- set feature_name = peri.name | lower -%}
 {% set_global all_peripheral_features = all_peripheral_features | concat(with=feature_name) %}
-{{feature_name}} = []
+{{feature_name}} = [{%- if peri.derived_from is string %} "{{peri.derived_from | lower}}" {% endif %}]
 {%- endfor %}
 {% if ir_csfr %}
 {%- for peri_mod_name, peri in ir_csfr.device.peripheral_mod %}

--- a/templates/rust/lib.tera
+++ b/templates/rust/lib.tera
@@ -25,13 +25,13 @@ pub mod tracing;
 {% endif %} {# tracing #}
 {% for peri_mod_name, peri in ir.device.peripheral_mod -%}
 {%- if peri.is_derived_from %} {% continue %} {% endif %} {# module that are derived doesn't have a module #}
-{%- set module_name = peri.name | to_mod_id -%}
+{%- set module_name = peri.module_id -%}
 #[cfg(feature = "{{module_name}}")]
 pub mod {{module_name}};
 {% endfor -%} {# for peri_mod_name, peri in ir.peripheral_mod #}
 {% if ir_csfr %}
 {% for peri_mod_name, peri in ir_csfr.device.peripheral_mod -%}
-{%- set module_name = peri.name | to_mod_id -%}
+{%- set module_name = peri.module_id -%}
 #[cfg(feature = "{{module_name}}")]
 pub mod {{module_name}};
 #[cfg(feature = "{{module_name}}")]
@@ -40,13 +40,15 @@ pub use {{module_name}} as csfr_cpu;
 {% endif %}
 
 {% for name,p in ir.device.peripheral_mod %}
-{%- set module_name = p.name | to_mod_id -%}
-{% set peri_struct = p.name | to_struct_id -%}
+{%- set module_name = p.module_id -%}
+{% set peri_struct = p.struct_id -%}
+{%- if not p.is_derived_from -%}
 #[cfg(feature = "{{module_name}}")] {# Peripheral definition #}
 #[derive(Copy, Clone, Eq, PartialEq)] 
 pub struct {{ peri_struct }}{ptr:*mut u8}
+{%- endif -%}
 {# Peripheral instances #}
-{%- set module_struct = p.name | to_struct_id -%}
+{%- set module_struct = p.struct_id -%}
 {%- set full_path_struct = "self::" ~ module_struct -%}
 #[cfg(feature = "{{module_name}}")]
 {%- if p.base_addr | length == 1 %}
@@ -60,7 +62,7 @@ pub const {{name | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [
 {%- set module_struct = "csfr_cpu" | to_struct_id -%}
 {%- set full_path_struct = "self::" ~ module_struct -%}
 {% for name,p in ir_csfr.device.peripheral_mod %}
-{%- set module_name = p.name | to_mod_id -%}
+{%- set module_name = p.module_id -%}
 {% if not loop.last %}feature = "{{module_name}}",{% else %}feature = "{{module_name}}"))]
 #[derive(Copy, Clone, Eq, PartialEq)] 
 pub struct {{ module_struct }}{ptr:*mut u8}
@@ -70,7 +72,7 @@ pub struct {{ module_struct }}{ptr:*mut u8}
 {%- set module_struct = "csfr_cpu" | to_struct_id -%}
 {%- set full_path_struct = "self::" ~ module_struct -%}
 {% for name,p in ir_csfr.device.peripheral_mod %}
-{%- set module_name = p.name | to_mod_id -%}
+{%- set module_name = p.module_id -%}
 {% if not loop.last %}feature = "{{module_name}}",{% else %}feature = "{{module_name}}"))]
 {%- if p.base_addr | length == 1 %}
 pub const {{"csfr_cpu" | upper}}: {{full_path_struct}} = {{full_path_struct}}{ptr:{{p.base_addr[0] | to_hex }}u32 as _};
@@ -145,8 +147,8 @@ unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
 /// Required for compatibility with RTIC and other frameworks
 pub struct Peripherals {
     {% for name,p in ir.device.peripheral_mod %}
-    {%- set module_name = p.name | to_mod_id -%}
-    {%- set module_struct = p.name | to_struct_id -%}
+    {%- set module_name = p.module_id -%}
+    {%- set module_struct = p.struct_id -%}
     {%- set full_path_struct = "self::" ~ module_struct -%}
     #[cfg(feature = "{{module_name}}")]
     {%- if p.base_addr | length == 1 %}
@@ -157,8 +159,8 @@ pub struct Peripherals {
     {%- endfor -%}
     {% if ir_csfr %}
     {% for name,p in ir_csfr.device.peripheral_mod %}
-    {%- set module_name = p.name | to_mod_id -%}
-    {%- set module_struct = p.name | to_struct_id -%}
+    {%- set module_name = p.module_id -%}
+    {%- set module_struct = p.struct_id -%}
     {%- set full_path_struct = module_name ~ "::" ~ module_struct -%}
     #[cfg(feature = "{{module_name}}")]
     {%- if p.base_addr | length == 1 %}
@@ -187,8 +189,8 @@ impl Peripherals {
         
         Peripherals{
             {% for name,p in ir.device.peripheral_mod %}
-            {%- set module_name = p.name | to_mod_id -%}
-            {%- set module_struct = p.name | to_struct_id -%}
+            {%- set module_name = p.module_id -%}
+            {%- set module_struct = p.struct_id -%}
             {%- set full_path_struct = module_name ~ "::" ~ module_struct %}
             #[cfg(feature = "{{module_name}}")]
             {{name | upper}}: crate::{{name | upper}},

--- a/templates/rust/lib.tera
+++ b/templates/rust/lib.tera
@@ -24,7 +24,7 @@ pub mod reg_name;
 pub mod tracing;
 {% endif %} {# tracing #}
 {% for peri_mod_name, peri in ir.device.peripheral_mod -%}
-{%- if peri.is_derived_from %} {% continue %} {% endif %} {# module that are derived doesn't have a module #}
+{%- if peri.derived_from is string %} {% continue %} {% endif %} {# module that are derived doesn't have a module #}
 {%- set module_name = peri.module_id -%}
 {%- set feature_name = peri.name | lower -%}
 #[cfg(feature = "{{feature_name}}")]
@@ -45,7 +45,7 @@ pub use {{module_name}} as csfr_cpu;
 {%- set module_name = p.module_id -%}
 {% set peri_struct = p.struct_id -%}
 {%- set feature_name = p.name | lower -%}
-{%- if not p.is_derived_from -%}
+{%- if not (p.derived_from is string) -%}
 #[cfg(feature = "{{feature_name}}")] {# Peripheral definition #}
 #[derive(Copy, Clone, Eq, PartialEq)] 
 pub struct {{ peri_struct }}{ptr:*mut u8}

--- a/templates/rust/lib.tera
+++ b/templates/rust/lib.tera
@@ -26,15 +26,17 @@ pub mod tracing;
 {% for peri_mod_name, peri in ir.device.peripheral_mod -%}
 {%- if peri.is_derived_from %} {% continue %} {% endif %} {# module that are derived doesn't have a module #}
 {%- set module_name = peri.module_id -%}
-#[cfg(feature = "{{module_name}}")]
+{%- set feature_name = peri.name | lower -%}
+#[cfg(feature = "{{feature_name}}")]
 pub mod {{module_name}};
 {% endfor -%} {# for peri_mod_name, peri in ir.peripheral_mod #}
 {% if ir_csfr %}
 {% for peri_mod_name, peri in ir_csfr.device.peripheral_mod -%}
 {%- set module_name = peri.module_id -%}
-#[cfg(feature = "{{module_name}}")]
+{%- set feature_name = peri.name | lower -%}
+#[cfg(feature = "{{feature_name}}")]
 pub mod {{module_name}};
-#[cfg(feature = "{{module_name}}")]
+#[cfg(feature = "{{feature_name}}")]
 pub use {{module_name}} as csfr_cpu;
 {% endfor -%}
 {% endif %}
@@ -42,15 +44,16 @@ pub use {{module_name}} as csfr_cpu;
 {% for name,p in ir.device.peripheral_mod %}
 {%- set module_name = p.module_id -%}
 {% set peri_struct = p.struct_id -%}
+{%- set feature_name = p.name | lower -%}
 {%- if not p.is_derived_from -%}
-#[cfg(feature = "{{module_name}}")] {# Peripheral definition #}
+#[cfg(feature = "{{feature_name}}")] {# Peripheral definition #}
 #[derive(Copy, Clone, Eq, PartialEq)] 
 pub struct {{ peri_struct }}{ptr:*mut u8}
 {%- endif -%}
 {# Peripheral instances #}
 {%- set module_struct = p.struct_id -%}
 {%- set full_path_struct = "self::" ~ module_struct -%}
-#[cfg(feature = "{{module_name}}")]
+#[cfg(feature = "{{feature_name}}")]
 {%- if p.base_addr | length == 1 %}
 pub const {{name | upper}}: {{full_path_struct}} = {{full_path_struct}}{ptr:{{p.base_addr[0] | to_hex }}u32 as _};
 {% else %}
@@ -63,7 +66,8 @@ pub const {{name | upper}}:[{{full_path_struct}};{{ p.base_addr | length }}] = [
 {%- set full_path_struct = "self::" ~ module_struct -%}
 {% for name,p in ir_csfr.device.peripheral_mod %}
 {%- set module_name = p.module_id -%}
-{% if not loop.last %}feature = "{{module_name}}",{% else %}feature = "{{module_name}}"))]
+{%- set feature_name = p.name | lower -%}
+{% if not loop.last %}feature = "{{feature_name}}",{% else %}feature = "{{feature_name}}"))]
 #[derive(Copy, Clone, Eq, PartialEq)] 
 pub struct {{ module_struct }}{ptr:*mut u8}
 {% endif %}
@@ -73,7 +77,8 @@ pub struct {{ module_struct }}{ptr:*mut u8}
 {%- set full_path_struct = "self::" ~ module_struct -%}
 {% for name,p in ir_csfr.device.peripheral_mod %}
 {%- set module_name = p.module_id -%}
-{% if not loop.last %}feature = "{{module_name}}",{% else %}feature = "{{module_name}}"))]
+{%- set feature_name = p.name | lower -%}
+{% if not loop.last %}feature = "{{feature_name}}",{% else %}feature = "{{feature_name}}"))]
 {%- if p.base_addr | length == 1 %}
 pub const {{"csfr_cpu" | upper}}: {{full_path_struct}} = {{full_path_struct}}{ptr:{{p.base_addr[0] | to_hex }}u32 as _};
 {% else %}
@@ -149,8 +154,9 @@ pub struct Peripherals {
     {% for name,p in ir.device.peripheral_mod %}
     {%- set module_name = p.module_id -%}
     {%- set module_struct = p.struct_id -%}
+    {%- set feature_name = p.name | lower -%}
     {%- set full_path_struct = "self::" ~ module_struct -%}
-    #[cfg(feature = "{{module_name}}")]
+    #[cfg(feature = "{{feature_name}}")]
     {%- if p.base_addr | length == 1 %}
     pub {{name | upper}}: {{full_path_struct}},
     {% else %}
@@ -162,7 +168,7 @@ pub struct Peripherals {
     {%- set module_name = p.module_id -%}
     {%- set module_struct = p.struct_id -%}
     {%- set full_path_struct = module_name ~ "::" ~ module_struct -%}
-    #[cfg(feature = "{{module_name}}")]
+    #[cfg(feature = "{{feature_name}}")]
     {%- if p.base_addr | length == 1 %}
     pub {{name | upper}}: {{full_path_struct}},
     {% else %}
@@ -192,7 +198,8 @@ impl Peripherals {
             {%- set module_name = p.module_id -%}
             {%- set module_struct = p.struct_id -%}
             {%- set full_path_struct = module_name ~ "::" ~ module_struct %}
-            #[cfg(feature = "{{module_name}}")]
+            {%- set feature_name = p.name | lower -%}
+            #[cfg(feature = "{{feature_name}}")]
             {{name | upper}}: crate::{{name | upper}},
             {%- endfor %}
         

--- a/templates/rust/peri_mod.tera
+++ b/templates/rust/peri_mod.tera
@@ -12,7 +12,7 @@ use crate::common::{*};
 #[allow(unused_imports)]
 use crate::common::sealed;
 #[doc = r"{{peri.description | svd_description_to_doc}}"]
-{% set peri_struct = peri.name | to_struct_id -%}
+{% set peri_struct = peri.struct_id -%}
 unsafe impl core::marker::Send for super::{{ peri_struct }} {}
 unsafe impl core::marker::Sync for super::{{ peri_struct }} {}
 impl super::{{ peri_struct }} {

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -982,6 +982,34 @@
 			<description>DerivedPeripheral</description>
 			<baseAddress>0x70200000</baseAddress>
 		</peripheral>
+		<peripheral>
+      <name>HasHeaderStruct</name>
+      <headerStructName>HeaderStruct</headerStructName>
+			<version>1.0</version>
+			<description>Peripheral with a headerStructName</description>
+			<baseAddress>0x70300000</baseAddress>
+			<access>read-write</access>
+			<addressBlock>
+				<offset>0</offset>
+				<size>0x100</size>
+				<usage>registers</usage>
+			</addressBlock>
+			<registers>
+				<cluster>
+					<name>I2C2</name>
+					<description>Cluster that defines the base type</description>
+					<addressOffset>0x0</addressOffset>
+					<register>
+						<name>Reg1</name>
+						<addressOffset>0x00</addressOffset>
+					</register>
+					<register>
+						<name>Reg2</name>
+						<addressOffset>0x4</addressOffset>
+					</register>
+				</cluster>
+			</registers>
+		</peripheral>
 	</peripherals>
 	<vendorExtensions>
 		<aurixCSFR>

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -983,8 +983,8 @@
 			<baseAddress>0x70200000</baseAddress>
 		</peripheral>
 		<peripheral>
-      <name>HasHeaderStruct</name>
-      <headerStructName>HeaderStruct</headerStructName>
+			<name>HasHeaderStruct</name>
+			<headerStructName>HeaderStruct</headerStructName>
 			<version>1.0</version>
 			<description>Peripheral with a headerStructName</description>
 			<baseAddress>0x70300000</baseAddress>
@@ -1009,6 +1009,20 @@
 					</register>
 				</cluster>
 			</registers>
+		</peripheral>
+		<peripheral derivedFrom="P33">
+			<name>HdrStrDer</name>
+			<headerStructName>HdrStructDerivedP33</headerStructName>
+			<version>1.0</version>
+			<description>Peripheral with a headerStructName and derived from another peripheral</description>
+			<baseAddress>0x70400000</baseAddress>
+		</peripheral>
+		<peripheral derivedFrom="HasHeaderStruct">
+			<name>HdrStrDerHdrStruct</name>
+			<headerStructName>HdrStructDerivedHdr</headerStructName>
+			<version>1.0</version>
+			<description>Peripheral with a headerStructName and derived from peripheral with headerStructName</description>
+			<baseAddress>0x70500000</baseAddress>
 		</peripheral>
 	</peripherals>
 	<vendorExtensions>

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -30,9 +30,6 @@ pub fn assert_cargo_build(package_folder: tempfile::TempDir) {
     let mut command = Command::new("cargo");
     command.arg("build");
     command.current_dir(package_folder.path());
-    // Error on invalid cfg(feature) directives
-    command.env("RUSTFLAGS", "-D unexpected_cfgs");
-
     let exec_result = command.output();
 
     if exec_result.is_err() {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -30,6 +30,8 @@ pub fn assert_cargo_build(package_folder: tempfile::TempDir) {
     let mut command = Command::new("cargo");
     command.arg("build");
     command.current_dir(package_folder.path());
+    // Error on invalid cfg(feature) directives
+    command.env("RUSTFLAGS", "-D unexpected_cfgs");
 
     let exec_result = command.output();
 


### PR DESCRIPTION
PR #37 uses the `headerStructName` field to define module and structure names. However, this change was not consistently applied throughout the generated code -- most references to peripherals use the peripheral name even if a header struct name is explicitly set. PSoC SVD files produce many compile errors when #37 is applied due to this inconsistency.

This commit changes all references to peripheral structures and modules to use the `module_id` and `struct_id` fields instead of inferring it from the peripheral names. Additionally, the peripheral `module_id` is now derived from the `headerStructName` for consistency with the logic in `push_current_item_svd_path`.

I encountered some issues with feature flags -- the existing logic in `Cargo_toml.tera` assumed that, in the case of a derived peripheral, the peripheral's feature flag would be the peripheral's name converted to a module identifier, and that the parent feature flag would be the peripheral's module identifier. However, in the case of peripheral derived from a struct with a `headerStructName`, this logic fails as the parent peripheral's name is not the same as its module identifier. I fixed this by changing the feature flag name to match the module name instead of the peripheral name. **This change means derived peripherals no longer have separate feature flags from their parents** -- if this is undesirable, an alternative would be to continue using the peripheral name for the feature flag, and add a field to the IR representation of a derived peripheral that allows us to keep track of the parent peripheral name when it's distinct from the module name.  

Lastly, this commit adds a test case of a simple peripheral with a `headerStructName`, which fails before this commit and passes after.

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md