### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Run '....'
+3. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**SVD file (snippet) and/or code snippet**
+If applicable, add an SVD/code snippet that shows the issue. You can also attach an SVD file if necessary/helpful.
+
+**Additional context**
+Add any other context about the problem here. (i.e. specific Rust version etc.)

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature-request---question.md
+++ b/.github/ISSUE_TEMPLATE/feature-request---question.md
@@ -1,0 +1,20 @@
+---
+name: Feature request / Question
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,14 @@
+## Description
+Provide the information we need to review your PR. What problem does the pull request solve?
+For larger issues think about chatting with us first (e.g. in a "Question" issue).
+
+## Related Issue
+If you opened an issue before creating the PR, point to it here.
+
+## Context
+What do we need to know about your development environment, tools, target, and so on. Screenshots are always helpful if there is a UI element to this PR.
+
+--- please keep the agreement as part of the PR text ---
+By creating this pull request you agree to the terms in CONTRIBUTING.md.
+https://github.com/Infineon/svd2pac/blob/main/CONTRIBUTING.md
+CONTRIBUTING.md also tells you what to expect in the PR process.


### PR DESCRIPTION
The old (IFX default) templates had a few issues:
- pointing to non-existent files
- pointing to the IFX Developer community, which won't be very helpful for this repo
- the ugly PR template header...

With this we replace both the issue templates and the PR template

Fixes #31 