### PR TITLE
Use a custom type to represent clusters instead of an array

### DIFF
--- a/templates/rust/common.tera
+++ b/templates/rust/common.tera
@@ -909,13 +909,13 @@ pub struct ClusterArray<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> 
 impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ClusterArray<T, DIM, DIM_INCREMENT> {
     /// Returns the number of register blocks in the cluster.
     #[inline(always)]
-    pub fn len(&self) -> usize {
+    pub const fn len(&self) -> usize {
         DIM
     }
 
     /// Returns whether the cluster is empty (DIM == 0).
     #[inline(always)]
-    pub fn is_empty(&self) -> bool {
+    pub const fn is_empty(&self) -> bool {
         DIM == 0
     }
 
@@ -928,7 +928,8 @@ impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ClusterArray<T, DIM
     /// Returns the cluster element with the specified index.
     /// 
     /// Panics if the index is out of bounds.
-    pub fn get(&self, index: usize) -> &T {
+    #[inline]
+    pub const fn get(&self, index: usize) -> &T {
         assert!(index < DIM);
         unsafe { self.get_unchecked(index) }
     }
@@ -939,17 +940,17 @@ impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ClusterArray<T, DIM
     ///
     /// `index` must be less than `DIM`.
     #[inline(always)]
-    pub unsafe fn get_unchecked(&self, index: usize) -> &T {
+    pub const unsafe fn get_unchecked(&self, index: usize) -> &T {
         &*(self.as_ptr().add(index * DIM_INCREMENT) as *const _) 
     }
 
     #[inline(always)]
-    pub(crate) unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
+    pub(crate) const unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
         &*(ptr as *const Self)
     }
 
     #[inline(always)]
-    fn as_ptr(&self) -> *mut u8 {
+    const fn as_ptr(&self) -> *mut u8 {
         self as *const _ as *mut _
     }
 }
@@ -959,6 +960,7 @@ impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ::core::ops::Index<
 {
     type Output = T;
 
+    #[inline(always)]
     fn index(&self, index: usize) -> &T {
         self.get(index)
     }
@@ -969,6 +971,7 @@ impl<'a, T: Sized, const DIM: usize, const DIM_INCREMENT: usize> IntoIterator fo
     type Item = &'a T;
     type IntoIter = ClusterArrayIterator<'a, T, DIM, DIM_INCREMENT>;
 
+    #[inline(always)]
     fn into_iter(self) -> Self::IntoIter {
         ClusterArrayIterator {
             array: self,
@@ -984,6 +987,7 @@ pub struct ClusterArrayIterator<'a, T: Sized, const DIM: usize, const DIM_INCREM
 
 impl<'a, T: Sized, const DIM: usize, const DIM_INCREMENT: usize> Iterator for ClusterArrayIterator<'a, T, DIM, DIM_INCREMENT> {
     type Item = &'a T;
+    #[inline(always)]
     fn next(&mut self) -> Option<&'a T> {
         if self.index < self.array.len() {
             let result = &self.array[self.index];
@@ -994,6 +998,7 @@ impl<'a, T: Sized, const DIM: usize, const DIM_INCREMENT: usize> Iterator for Cl
         }
     }
 
+    #[inline(always)]
     fn size_hint(&self) -> (usize, Option<usize>) {
         let len = self.array.len() - self.index;
         (len, Some(len))

--- a/templates/rust/common.tera
+++ b/templates/rust/common.tera
@@ -900,3 +900,60 @@ where
         START_OFFSET + (self.index * DIM_INCREMENT) as usize
     }
 }
+
+/// A cluster of identical register blocks.
+pub struct Cluster<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> {
+    _t: ::core::marker::PhantomData<T>,
+}
+
+impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> Cluster<T, DIM, DIM_INCREMENT> {
+    /// Returns the number of register blocks in the cluster.
+    pub fn len() -> usize {
+        DIM
+    }
+
+    /// Returns whether the cluster is empty (DIM == 0).
+    pub fn is_empty() -> bool {
+        DIM == 0
+    }
+
+    /// Returns an iterator over the elements of this cluster.
+    pub fn iter(&self) -> impl ::core::iter::ExactSizeIterator<Item = &T> {
+        (0..DIM).map(|i| &self[i])
+    }
+
+    /// Returns the cluster element with the specified index.
+    /// 
+    /// Panics if the index is out of bounds.
+    pub fn get(&self, index: usize) -> &T {
+        assert!(index < DIM);
+        unsafe { self.get_unchecked(index) }
+    }
+
+    /// Returns the cluster element with the specified index.
+    ///
+    /// # Safety
+    ///
+    /// `index` must be less than `DIM`.
+    pub unsafe fn get_unchecked(&self, index: usize) -> &T {
+        &*(self.as_ptr().add(index * DIM_INCREMENT) as *const _) 
+    }
+
+    pub(crate) unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
+        &*(ptr as *const Self)
+    }
+
+    fn as_ptr(&self) -> *mut u8 {
+        self as *const _ as *mut _
+    }
+}
+
+impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ::core::ops::Index<usize>
+    for Cluster<T, DIM, DIM_INCREMENT>
+{
+    type Output = T;
+
+    fn index(&self, index: usize) -> &T {
+        self.get(index)
+    }
+}

--- a/templates/rust/common.tera
+++ b/templates/rust/common.tera
@@ -901,25 +901,28 @@ where
     }
 }
 
-/// A cluster of identical register blocks.
-pub struct Cluster<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> {
+/// An array of identical register clusters.
+pub struct ClusterArray<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> {
     _t: ::core::marker::PhantomData<T>,
 }
 
-impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> Cluster<T, DIM, DIM_INCREMENT> {
+impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ClusterArray<T, DIM, DIM_INCREMENT> {
     /// Returns the number of register blocks in the cluster.
-    pub fn len() -> usize {
+    #[inline(always)]
+    pub fn len(&self) -> usize {
         DIM
     }
 
     /// Returns whether the cluster is empty (DIM == 0).
-    pub fn is_empty() -> bool {
+    #[inline(always)]
+    pub fn is_empty(&self) -> bool {
         DIM == 0
     }
 
     /// Returns an iterator over the elements of this cluster.
+    #[inline(always)]
     pub fn iter(&self) -> impl ::core::iter::ExactSizeIterator<Item = &T> {
-        (0..DIM).map(|i| &self[i])
+        self.into_iter()
     }
 
     /// Returns the cluster element with the specified index.
@@ -935,21 +938,24 @@ impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> Cluster<T, DIM, DIM
     /// # Safety
     ///
     /// `index` must be less than `DIM`.
+    #[inline(always)]
     pub unsafe fn get_unchecked(&self, index: usize) -> &T {
         &*(self.as_ptr().add(index * DIM_INCREMENT) as *const _) 
     }
 
+    #[inline(always)]
     pub(crate) unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
         &*(ptr as *const Self)
     }
 
+    #[inline(always)]
     fn as_ptr(&self) -> *mut u8 {
         self as *const _ as *mut _
     }
 }
 
 impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ::core::ops::Index<usize>
-    for Cluster<T, DIM, DIM_INCREMENT>
+    for ClusterArray<T, DIM, DIM_INCREMENT>
 {
     type Output = T;
 
@@ -957,3 +963,41 @@ impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ::core::ops::Index<
         self.get(index)
     }
 }
+
+
+impl<'a, T: Sized, const DIM: usize, const DIM_INCREMENT: usize> IntoIterator for &'a ClusterArray<T, DIM, DIM_INCREMENT> {
+    type Item = &'a T;
+    type IntoIter = ClusterArrayIterator<'a, T, DIM, DIM_INCREMENT>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        ClusterArrayIterator {
+            array: self,
+            index: 0
+        }
+    }
+}
+
+pub struct ClusterArrayIterator<'a, T: Sized, const DIM: usize, const DIM_INCREMENT: usize> {
+    array: &'a ClusterArray<T, DIM, DIM_INCREMENT>,
+    index: usize
+}
+
+impl<'a, T: Sized, const DIM: usize, const DIM_INCREMENT: usize> Iterator for ClusterArrayIterator<'a, T, DIM, DIM_INCREMENT> {
+    type Item = &'a T;
+    fn next(&mut self) -> Option<&'a T> {
+        if self.index < self.array.len() {
+            let result = &self.array[self.index];
+            self.index += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let len = self.array.len() - self.index;
+        (len, Some(len))
+    }
+}
+
+impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ExactSizeIterator for ClusterArrayIterator<'_, T, DIM, DIM_INCREMENT> {}

--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -21,13 +21,13 @@ Unsupported register size
 #[inline(always)]
 {% if reg.dim == 1 -%}
 pub const fn {{reg.name | to_func_id }}(&self) -> crate::common::Reg<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}> {
-    unsafe { crate::common::Reg::from_ptr(self.as_ptr().add({{reg.offset}}usize)) }
+    unsafe { crate::common::Reg::from_ptr(self._svd2pac_as_ptr().add({{reg.offset}}usize)) }
 }
 {%- else -%}
 pub const fn {{reg.name | to_func_id }}(&self) -> [crate::common::Reg<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}>;{{reg.dim}}] {
     unsafe {  [
     {%- for index in range(end=reg.dim) -%}
-    crate::common::Reg::from_ptr(self.as_ptr().add({{reg.offset | to_hex }}usize + {{index * reg.dim_increment | to_hex }}usize )),
+    crate::common::Reg::from_ptr(self._svd2pac_as_ptr().add({{reg.offset | to_hex }}usize + {{index * reg.dim_increment | to_hex }}usize )),
     {% endfor -%}
     ] }
 }
@@ -125,12 +125,12 @@ pub mod {{reg_mod_name}} {
 #[doc = "{{cluster.description | svd_description_to_doc}}"]
 #[inline(always)]
 {%- if cluster.dim == 1 %}
-pub fn {{cluster_func}}(self) -> {{cluster_struct_path}}{
-    unsafe {   {{underscored_cluster_struct_path}}::from_ptr(self.as_ptr().add({{cluster.offset}}usize)) }
+pub const fn {{cluster_func}}(self) -> {{cluster_struct_path}}{
+    unsafe {   {{underscored_cluster_struct_path}}::_svd2pac_from_ptr(self._svd2pac_as_ptr().add({{cluster.offset}}usize)) }
 }
 {%- else %}
-pub fn {{cluster_func}}(self) -> &'static crate::common::Cluster<{{underscored_cluster_struct_path}}, {{cluster.dim}}, {{cluster.dim_increment | to_hex}}> {
-    unsafe { crate::common::Cluster::from_ptr(self.as_ptr().add({{cluster.offset | to_hex}}usize)) }
+pub fn {{cluster_func}}(self) -> &'static crate::common::ClusterArray<{{underscored_cluster_struct_path}}, {{cluster.dim}}, {{cluster.dim_increment | to_hex}}> {
+    unsafe { crate::common::ClusterArray::from_ptr(self._svd2pac_as_ptr().add({{cluster.offset | to_hex}}usize)) }
 }
 {%- endif -%}
 {%- endmacro -%}
@@ -151,12 +151,14 @@ pub type {{ cluster_struct }} = &'static _{{ cluster_struct }};
 unsafe impl ::core::marker::Sync for _{{ cluster_struct }} {}
 impl _{{cluster_struct}} {
     #[allow(unused)]
-    pub(crate) unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
+    #[inline(always)]
+    pub(crate) const unsafe fn _svd2pac_from_ptr(ptr: *mut u8) -> &'static Self {
         &*(ptr as *mut _)
     }
 
     #[allow(unused)]
-    pub(crate) const fn as_ptr(&self) -> *mut u8 {
+    #[inline(always)]
+    pub(crate) const fn _svd2pac_as_ptr(&self) -> *mut u8 {
         self as *const Self as *mut u8
     }
 

--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -21,13 +21,13 @@ Unsupported register size
 #[inline(always)]
 {% if reg.dim == 1 -%}
 pub const fn {{reg.name | to_func_id }}(&self) -> crate::common::Reg<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}> {
-    unsafe { crate::common::Reg::from_ptr(self.ptr.add({{reg.offset}}usize)) }
+    unsafe { crate::common::Reg::from_ptr(self.as_ptr().add({{reg.offset}}usize)) }
 }
 {%- else -%}
 pub const fn {{reg.name | to_func_id }}(&self) -> [crate::common::Reg<{{reg_struct_name}}_SPEC, crate::common::{{reg.access}}>;{{reg.dim}}] {
     unsafe {  [
     {%- for index in range(end=reg.dim) -%}
-    crate::common::Reg::from_ptr(self.ptr.add({{reg.offset | to_hex }}usize + {{index * reg.dim_increment | to_hex }}usize )),
+    crate::common::Reg::from_ptr(self.as_ptr().add({{reg.offset | to_hex }}usize + {{index * reg.dim_increment | to_hex }}usize )),
     {% endfor -%}
     ] }
 }
@@ -120,20 +120,17 @@ pub mod {{reg_mod_name}} {
 {%- set mod_struct_path = cluster.struct_module_path | join(sep="::") -%}
 {%- set cluster_struct_id = cluster.struct_id | to_struct_id -%}
 {%- set cluster_struct_path = "crate" ~ "::" ~ mod_struct_path ~ "::" ~ cluster_struct_id -%}
+{%- set underscored_cluster_struct_path = "crate" ~ "::" ~ mod_struct_path ~ "::_" ~ cluster_struct_id -%}
 {%- set cluster_func = cluster.name | to_func_id -%}
 #[doc = "{{cluster.description | svd_description_to_doc}}"]
 #[inline(always)]
 {%- if cluster.dim == 1 %}
 pub fn {{cluster_func}}(self) -> {{cluster_struct_path}}{
-    unsafe {   {{cluster_struct_path}}{ptr:self.ptr.add({{cluster.offset}}usize)} }
+    unsafe {   {{underscored_cluster_struct_path}}::from_ptr(self.as_ptr().add({{cluster.offset}}usize)) }
 }
 {%- else %}
-pub fn {{cluster_func}}(self) -> [{{cluster_struct_path}};{{cluster.dim}}] {
-    unsafe {  [
-        {%- for index in range(end=cluster.dim) -%}
-        {{cluster_struct_path}}{ptr:self.ptr.add({{cluster.offset | to_hex}}usize + {{index*cluster.dim_increment | to_hex }}usize)},
-        {% endfor -%}
-        ] }
+pub fn {{cluster_func}}(self) -> &'static crate::common::Cluster<{{underscored_cluster_struct_path}}, {{cluster.dim}}, {{cluster.dim_increment | to_hex}}> {
+    unsafe { crate::common::Cluster::from_ptr(self.as_ptr().add({{cluster.offset | to_hex}}usize)) }
 }
 {%- endif -%}
 {%- endmacro -%}
@@ -145,11 +142,24 @@ pub fn {{cluster_func}}(self) -> [{{cluster_struct_path}};{{cluster.dim}}] {
 {%- set cluster_struct = cluster.struct_id | to_struct_id -%}
 {%- set cluster_mod = cluster.module_id -%}
 #[doc = "{{cluster.description | svd_description_to_doc}}"]
-#[derive(Copy, Clone, Eq, PartialEq)]
-pub struct {{ cluster_struct }}{pub(crate) ptr: *mut u8}
-unsafe impl ::core::marker::Send for {{ cluster_struct}} {}
-unsafe impl ::core::marker::Sync for {{ cluster_struct }} {}
-impl {{cluster_struct}} {
+#[non_exhaustive]
+pub struct _{{ cluster_struct }};
+
+#[doc = "{{cluster.description | svd_description_to_doc}}"]
+pub type {{ cluster_struct }} = &'static _{{ cluster_struct }};
+
+unsafe impl ::core::marker::Sync for _{{ cluster_struct }} {}
+impl _{{cluster_struct}} {
+    #[allow(unused)]
+    pub(crate) unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
+        &*(ptr as *mut _)
+    }
+
+    #[allow(unused)]
+    pub(crate) const fn as_ptr(&self) -> *mut u8 {
+        self as *const Self as *mut u8
+    }
+
     {% for register_name,reg in cluster.registers -%}
     {{self::register_func(types_mod=cluster_mod,reg=reg)}}
     {% endfor -%}

--- a/templates/rust/peri_mod.tera
+++ b/templates/rust/peri_mod.tera
@@ -16,6 +16,11 @@ use crate::common::sealed;
 unsafe impl ::core::marker::Send for super::{{ peri_struct }} {}
 unsafe impl ::core::marker::Sync for super::{{ peri_struct }} {}
 impl super::{{ peri_struct }} {
+    #[allow(unused)]
+    pub(crate) const fn as_ptr(&self) -> *mut u8 {
+        self.ptr
+    }
+
 {%- for register_name,reg in peri.registers %}
 {{macros::register_func(types_mod="self",reg=reg)}}
 {% endfor -%}

--- a/templates/rust/peri_mod.tera
+++ b/templates/rust/peri_mod.tera
@@ -17,7 +17,8 @@ unsafe impl ::core::marker::Send for super::{{ peri_struct }} {}
 unsafe impl ::core::marker::Sync for super::{{ peri_struct }} {}
 impl super::{{ peri_struct }} {
     #[allow(unused)]
-    pub(crate) const fn as_ptr(&self) -> *mut u8 {
+    #[inline(always)]
+    pub(crate) const fn _svd2pac_as_ptr(&self) -> *mut u8 {
         self.ptr
     }
 

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -593,7 +593,7 @@
 						<resetValue>0x1000</resetValue>
 						<fields>
 							<field>
-								<name>filed1</name>
+								<name>field1</name>
 								<lsb>0</lsb>
 								<msb>2</msb>
 								<access>read-write</access>

--- a/tests/resources/project_files_generic/src/bin/main.rs
+++ b/tests/resources/project_files_generic/src/bin/main.rs
@@ -93,6 +93,12 @@ fn main() -> ! {
 
         // Test 64Bit register
         TIMER.register64bit().modify(|r| r.boolean().set(crate::timer::register64bit::Boolean::FALSE));
+
+        // Test cluster array
+        TIMER.clusterdim()[0].cr().modify(|r| r.field1().set(0));
+        for elem in TIMER.clusterdim() {
+            TIMER.clusterdim()[0].cr().modify(|r| r.field1().set(1));
+        }
     }
     loop {}
 }


### PR DESCRIPTION
## Description

Introduce a `Cluster` type that represents a cluster of register blocks, with an `Index` impl that computes the address of the register we're interested in, instead of computing all the register addresses up front to store them in an array. This provides a significant improvement in code size.

We have to do some trickery in order to support subscripting, because the `Index` trait only supports indexes returning references. This commit implements the solution proposed by @pellico: represent a register block within a cluster as a reference to a zero-sized type. Any non-null, sufficiently aligned reference to a ZST is valid, so we can forge references to ZSTs and use the address of the reference to represent the address of the register block. This is sound as long as we never expose an *owned* ZST to safe code, and we mark the cluster ZST types as `#[non_exhaustive]` so users can't construct their own.

## Code size impacts

Recompiling a small test application with this change reduced code size from 13388 bytes to 12104 bytes. Adding a couple of strategic `get_unchecked` calls within the GPIO driver (where it is safe to do so because the port number is checked at compile time) reduced code size further to 11700 bytes. That's a 13% reduction in code size!

The following is a screenshot of code generated by the compiler before this change, configured to optimize for size:

<img width="2032" alt="Screenshot 2024-12-13 at 5 02 18 PM" src="https://github.com/user-attachments/assets/c143ce03-690e-420e-84d7-c868fefe2ea5" />

This function sets a single field in a GPIO configuration register. Just *reading* the register's previous value took 106 bytes of machine code, and then the compiler emitted a separate 134-byte function to write the new value back to the register. That's 240 bytes, just to change 2 bits of a register.

Here's the same function after this change:

<img width="2032" alt="Screenshot 2024-12-13 at 5 02 13 PM" src="https://github.com/user-attachments/assets/ee7c340a-5c9b-49f0-974c-98e3823ada6b" />

Down to 40 bytes! And it can get even smaller: if the port and pin number are statically known, the compiler can constant-fold and issue instructions to directly access the register's memory address instead of having to compute it.

## Documentation impacts

Not nearly as I feared, since the ZST reference trick is only needed for clusters structs, not every single peripheral struct.  

Here's what rustdoc looked like before:

<img width="257" alt="Screenshot 2024-12-13 at 4 25 24 PM" src="https://github.com/user-attachments/assets/76534b2b-030d-4915-a8c7-af1153dacf06" />
<img width="1118" alt="Screenshot 2024-12-13 at 4 26 13 PM" src="https://github.com/user-attachments/assets/7d6d43ae-89f4-4cd1-847e-bd30cfe97089" />
<img width="1146" alt="Screenshot 2024-12-13 at 4 25 44 PM" src="https://github.com/user-attachments/assets/fa62d8ee-504a-40a9-bc4f-4eada3e68efc" />

And here's after:
<img width="453" alt="Screenshot 2024-12-13 at 5 17 46 PM" src="https://github.com/user-attachments/assets/90387f43-1cc2-4609-8581-bb06db43008c" />
<img width="1111" alt="Screenshot 2024-12-13 at 5 13 19 PM" src="https://github.com/user-attachments/assets/d701e811-5e86-4c4b-875c-7de48fe43d0b" />
<img width="1111" alt="Screenshot 2024-12-13 at 5 13 23 PM" src="https://github.com/user-attachments/assets/5495cb98-882e-445c-8093-9490be38777d" />
<img width="1111" alt="Screenshot 2024-12-13 at 5 13 27 PM" src="https://github.com/user-attachments/assets/64b7c7fd-0326-4309-b202-565ece3b935c" />

## Compatibility impacts

This change is *almost* entirely source-compatible. However, some minor source changes may be required because Rust tries to automatically dereference the result of an indexing operation. If a user accesses `cluster()[i]` and stores the result in a variable or returns it from a function, they may need to add an `&` or call `cluster().get(i)` in order to reference the register instead of trying to move it. The error message is clear and the compiler suggests a fix:

<img width="781" alt="Screenshot 2024-12-13 at 5 46 35 PM" src="https://github.com/user-attachments/assets/0d0eb058-b904-4ed9-9802-432c43ef8c54" />

## Related Issue
Fixes #46

--- please keep the agreement as part of the PR text ---
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/svd2pac/blob/main/CONTRIBUTING.md
CONTRIBUTING.md also tells you what to expect in the PR process.
