### PR TITLE
Add write_raw to register

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /generated_code/
 /lcov.info
 
+# temp folders for test run
+/.tmp*

--- a/README.md
+++ b/README.md
@@ -278,7 +278,11 @@ possible to read/write registers as plain integers.
 // get register value as integer value
 let to_log = unsafe { TIMER.sr().read().get_raw() };
 
-// write register with integer value, e.g. read from table
+// write register with opaque integer value
+unsafe { TIMER.bitfield_reg().write_raw(0x42dead42) };
+
+// write register with opaque integer value, e.g. read from table
+// `set_raw` can be mixed with other bitfield setting functions
 unsafe { TIMER.bitfield_reg().modify(|r| r.set_raw(0x1234)) };
 ```
 

--- a/templates/rust/common.tera
+++ b/templates/rust/common.tera
@@ -312,8 +312,8 @@ where
     /// * `reg_value` - A string slice that holds the name of the person
     ///
     /// # Safety
-    /// Write operation could cause undefined behavior for some peripheral. Developer shall read device user manual.
-    /// Register is Send and Sync to allow complete freedom. Developer is responsible of proper use in interrupt and thread.
+    /// Write operation could cause undefined behavior for some peripheral. Developers shall read the device user manual.
+    /// Register is Send and Sync to allow complete freedom. Developers are responsible of proper use in interrupt and thread.
     ///
     /// # Example
     /// ```rust,ignore
@@ -350,6 +350,49 @@ where
         #[cfg(not(feature = "tracing"))]
         {% endif -%}
         self.ptr().write_volatile(reg_value.data);
+    }
+
+
+    /// Write an arbitrary integer to register
+    ///
+    /// Use this function when e.g. loading data to be written from a config-page.
+    /// For normal use prefer either [`Reg<T, A>::write`] if the value was read before, or [`Reg<T, A>::init`],
+    /// both of which provide some restrictions available register fields, enums, etc.
+    ///
+    /// # Arguments
+    ///
+    /// * `value` - The unchecked value to be written to the register
+    ///
+    /// # Safety
+    ///
+    /// Write operation could cause undefined behavior for some peripheral. Developers shall read the device user manual.
+    /// Register is Send and Sync to allow complete freedom. Developers are responsible of proper use in interrupt and thread.
+    ///
+    /// # Example
+    /// ```rust,ignore
+    /// // example with generic names
+    /// unsafe { TIMER.bitfield_reg().write_raw(0xdead) }
+    /// ```
+    /// See also [`Reg<T, A>::init`] and [`Reg<T, A>::write`] both of which are the safe, preferred functions.
+    #[inline(always)]
+    pub unsafe fn write_raw(&self, value: T::DataType) {
+        {% if tracing %}
+        #[cfg(feature = "tracing")]
+        tracing::WRITE_FN.with(|wf| {
+            if let Some(wf) = wf.get() {
+                wf(
+                    self.addr(),
+                    std::mem::size_of::<T::DataType>(),
+                    value.into(),
+                )
+            } else {
+                #[cfg(not(feature = "tracing_dummy"))]
+                panic!("Please, provide an handler for read with tracing::set_read_fn(callback);");
+            }
+        });
+        #[cfg(not(feature = "tracing"))]
+        {% endif %}
+        self.ptr().write_volatile(value);
     }
 }
 

--- a/tests/resources/project_files_aurix/src/bin/main.rs
+++ b/tests/resources/project_files_aurix/src/bin/main.rs
@@ -35,6 +35,9 @@ fn main() -> ! {
                 .set(3)
         });
 
+        // write raw
+        TIMER.bitfield_reg().write_raw(0x123);
+
         // Modify atomic only 32bit registers
         TIMER.bitfield_reg().modify_atomic(|f| {
             f.bitfieldenumerated()

--- a/tests/resources/project_files_generic/src/bin/main.rs
+++ b/tests/resources/project_files_generic/src/bin/main.rs
@@ -35,6 +35,9 @@ fn main() -> ! {
                 .set(3)
         });
 
+        // write raw
+        TIMER.bitfield_reg().write_raw(0x123);
+
         // Array of register bitfields
         let mut a = TIMER.bitfield_reg().read();
         for x in 0..2 {

--- a/tests/resources/project_files_tracing/src/bin/main.rs
+++ b/tests/resources/project_files_tracing/src/bin/main.rs
@@ -40,6 +40,9 @@ fn main() -> ! {
                 .set(3)
         });
 
+        // write rawG
+        TIMER.bitfield_reg().write_raw(0x123);
+
         // Array of register bitfields
         let mut a = TIMER.bitfield_reg().read();
         for x in 0..2 {


### PR DESCRIPTION
Fixes #49

Adds a `write_raw` function to registers for writing known values to a register.

The alternative that I considered was to implement `Into` for `RegValue`.
This would essentially provide the same capability, but:
- we have `set_raw` on the bitfield types, `write_raw` seems more consistent
- to me `write_raw` more clearly communicates what's happening, `0.into()` to me hides a bit that we are bypassing all the enum/bitfield "safety" that we otherwise have

By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/.github/blob/master/CONTRIBUTING.md
--- DO NOT DELETE ANYTHING ABOVE THIS LINE ---
