### PR TITLE
Update CI cache action to v4

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,9 +19,7 @@ jobs:
       - run: rustup update stable && rustup default stable
       - run: cargo --version --verbose && rustc --version
       - name: Cache dependencies
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-dependencies
+        uses: actions/cache@v4
         with:
           path: |
             ~/.cargo/.crates.toml


### PR DESCRIPTION
v2 has been deprecated, v4 is the current default
see also: https://github.com/actions/cache
