### PR TITLE
Fix bug causing all documentation to be omitted

### DIFF
--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -14,7 +14,7 @@ Unsupported register size
 
 {%- macro doc_attribute(documentation) -%}
 {%- set doc_string = documentation | svd_description_to_doc -%}
-{%- if doc_string is not matching("") %} 
+{%- if doc_string != "" %} 
 #[doc = "{{doc_string}}"]
 {%- endif -%}
 {%- endmacro -%}


### PR DESCRIPTION
The `matching` filter searches for a partial regex match, and the empty regex matches anything.

## Description

https://github.com/Infineon/svd2pac/commit/f015ea4b767eafc1f410f435a57d07ab976973fd [added the following check ](https://github.com/Infineon/svd2pac/commit/f015ea4b767eafc1f410f435a57d07ab976973fd#diff-c3a37bd32d597a7a8ee4051d10dfbd71cc5c1cc796f2da331e354369c1f7c6baR18) to skip generating a `#[doc = "..."]` attribute for items with no documentation:

```
{%- if doc_string is not matching("") %} 
#[doc = "{{doc_string}}"]
{%- endif -%}
```

However, the `matching` filter uses a regex match, and the empty regex matches everything. Therefore, all documentation was skipped. This PR replaces the regex with a string comparison against the empty string.

--- please keep the agreement as part of the PR text ---
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/svd2pac/blob/main/CONTRIBUTING.md
CONTRIBUTING.md also tells you what to expect in the PR process.
