### PR TITLE
Add a map_addr method for transforming a register address

### DIFF
--- a/templates/rust/common.tera
+++ b/templates/rust/common.tera
@@ -96,6 +96,20 @@ pub trait Write: Access {}
 impl Write for RW {}
 impl Write for W {}
 
+/// Trait for the `as_ptr` and `from_ptr` methods,
+/// allowing register and cluster types to be converted to and from raw pointers.
+pub trait AsPtr {
+    /// Returns a raw pointer with the address of `self`.
+    fn as_ptr(&self) -> *mut u8;
+
+    /// Creates a new instance of this type from a raw pointer.
+    ///
+    /// # Safety
+    /// The pointer must be non-null, as well as valid and properly aligned for the read and write operations
+    /// performed on the resulting register instance.
+    unsafe fn from_ptr(ptr: *mut u8) -> &'static Self;
+}
+
 #[derive(Copy, Clone, PartialEq, Eq)]
 pub struct Reg<T, A: Access> {
     phantom: PhantomData<*mut (T, A)>,
@@ -240,7 +254,6 @@ where
     T: RegSpec,
     A: Access,
 {
-    #[allow(dead_code)]
     #[inline(always)]
     #[must_use]
     pub(crate) const fn from_ptr(ptr: *mut u8) -> &'static Self {
@@ -252,6 +265,7 @@ where
     pub const fn ptr(&self) -> *mut T::DataType {
         self as *const _ as *mut T::DataType
     }
+
     {% if tracing %}
     /// Returns the address of the register.
     pub fn addr(&self) -> usize {
@@ -259,6 +273,24 @@ where
     }
     {% endif %}
 }
+
+
+impl<T, A> AsPtr for Reg<T, A>
+where
+    T: RegSpec + 'static,
+    A: Access + 'static,
+{
+    #[inline(always)]
+    fn as_ptr(&self) -> *mut u8 {
+        self.ptr() as *mut u8
+    }
+
+    #[inline(always)]
+    unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
+        Self::from_ptr(ptr)
+    }
+}
+
 
 impl<T, A> Reg<T, A>
 where
@@ -995,7 +1027,6 @@ impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ClusterRegisterArra
         &*(self.as_ptr().add(index * DIM_INCREMENT) as *const _) 
     }
 
-    #[allow(dead_code)]
     #[inline(always)]
     pub(crate) const unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
         &*(ptr as *const Self)
@@ -1004,6 +1035,20 @@ impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ClusterRegisterArra
     #[inline(always)]
     const fn as_ptr(&self) -> *mut u8 {
         self as *const _ as *mut _
+    }
+}
+
+impl<T: Sized + 'static, const DIM: usize, const DIM_INCREMENT: usize>
+    AsPtr for ClusterRegisterArray<T, DIM, DIM_INCREMENT>
+{
+    #[inline(always)]
+    fn as_ptr(&self) -> *mut u8 {
+        self.as_ptr()
+    }
+
+    #[inline(always)]
+    unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
+        ClusterRegisterArray::from_ptr(ptr)
     }
 }
 

--- a/templates/rust/common.tera
+++ b/templates/rust/common.tera
@@ -98,13 +98,21 @@ impl Write for W {}
 
 /// Trait for the `as_ptr` and `from_ptr` methods,
 /// allowing register and cluster types to be converted to and from raw pointers.
-pub trait AsPtr {
+/// 
+/// # Safety
+///
+/// This trait is intended to be implemented by register and cluster types. The
+/// `as_ptr` method must return a valid pointer to the register's MMIO address,
+/// and calling `from_ptr` with the result of `as_ptr` (and vice versa) must
+/// correctly roundtrip.
+pub unsafe trait AsPtr {
     /// Returns a raw pointer with the address of `self`.
     fn as_ptr(&self) -> *mut u8;
 
     /// Creates a new instance of this type from a raw pointer.
     ///
     /// # Safety
+    ///
     /// The pointer must be non-null, as well as valid and properly aligned for the read and write operations
     /// performed on the resulting register instance.
     unsafe fn from_ptr(ptr: *mut u8) -> &'static Self;
@@ -275,7 +283,7 @@ where
 }
 
 
-impl<T, A> AsPtr for Reg<T, A>
+unsafe impl<T, A> AsPtr for Reg<T, A>
 where
     T: RegSpec + 'static,
     A: Access + 'static,
@@ -1038,7 +1046,7 @@ impl<T: Sized, const DIM: usize, const DIM_INCREMENT: usize> ClusterRegisterArra
     }
 }
 
-impl<T: Sized + 'static, const DIM: usize, const DIM_INCREMENT: usize>
+unsafe impl<T: Sized + 'static, const DIM: usize, const DIM_INCREMENT: usize>
     AsPtr for ClusterRegisterArray<T, DIM, DIM_INCREMENT>
 {
     #[inline(always)]

--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -176,13 +176,11 @@ pub type {{ cluster_struct }} = &'static _{{ cluster_struct }};
 
 unsafe impl ::core::marker::Sync for _{{ cluster_struct }} {}
 impl _{{cluster_struct}} {
-    #[allow(unused)]
     #[inline(always)]
     pub(crate) const unsafe fn _svd2pac_from_ptr(ptr: *mut u8) -> &'static Self {
         &*(ptr as *const _)
     }
 
-    #[allow(unused)]
     #[inline(always)]
     pub(crate) const fn _svd2pac_as_ptr(&self) -> *mut u8 {
         self as *const Self as *mut u8
@@ -195,6 +193,19 @@ impl _{{cluster_struct}} {
     {{self::cluster_func(types_mod=cluster_mod,cluster=cluster)}}
     {% endfor -%}
 }
+
+impl AsPtr for _{{cluster_struct}} {
+    fn as_ptr(&self) -> *mut u8 {
+        self._svd2pac_as_ptr()
+    }
+
+    #[inline(always)]
+    unsafe fn from_ptr(ptr: *mut u8) -> &'static Self {
+        Self::_svd2pac_from_ptr(ptr)
+    }
+}
+
+
 pub mod {{cluster_mod}} {
     #[allow(unused_imports)]
     use crate::common::{*};

--- a/templates/rust/macros.tera
+++ b/templates/rust/macros.tera
@@ -194,7 +194,7 @@ impl _{{cluster_struct}} {
     {% endfor -%}
 }
 
-impl AsPtr for _{{cluster_struct}} {
+unsafe impl AsPtr for _{{cluster_struct}} {
     fn as_ptr(&self) -> *mut u8 {
         self._svd2pac_as_ptr()
     }


### PR DESCRIPTION
On many processors implementing TrustZone, bit 28 of the address space is used to indicate whether a memory access is secure or non-secure, meaning drivers often need to bitwise-OR a security bit against the register address.

In order to support this with svd2pac, this commit adds a `map_addr` function to registers and clusters allowing a driver to override the register's address:

```rust
/// Creates a new register by mapping the addresss of this register. This is useful on platforms where
/// some bits of a transaction address are used to indicate flags (such as a TrustZone security attribute).
///
/// # Safety
/// The address must be non-null, as well as valid and properly aligned for the read and write operations
/// performed on the resulting register instance.
#[must_use]
unsafe fn map_addr(&self, f: impl FnOnce(usize) -> usize) -> &Self;
```

The function is implemented as a trait method for two reasons:

- To avoid naming collisions in case a cluster has a register named `map_addr`.
- So that drivers can build safe abstractions on top of `map_addr`, like:

```rust
/// Helper trait for applying a security attribute to a register address.
pub trait WithSecurity {
    /// Applies a security attribute to the address referenced by `self`.
    fn with_security(self, security: impl Security) -> Self;
}

impl<T: pac::MapAddr> WithSecurity for &T {
    fn with_security(self, security: impl Security) -> Self {
        unsafe { self.map_addr(|addr| security.map_addr(addr)) }
    }
}
```

The function signature intentionally mirrors [std's `map_addr`][map_addr] function on pointer types.

[map_addr]: https://doc.rust-lang.org/std/primitive.pointer.html#method.map_addr-1