### PR TITLE
Add #![allow(non_snake_case)] to supress warnings from double underscores

### DIFF
--- a/templates/rust/lib.tera
+++ b/templates/rust/lib.tera
@@ -13,6 +13,7 @@
 #![cfg_attr(target_arch = "tricore", feature(stdsimd))]
 {% endif %}
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![doc = "{{ir.device.description | svd_description_to_doc}}"]
 pub mod common;
 pub use common::*;

--- a/test_reference/aurix/src/lib.rs
+++ b/test_reference/aurix/src/lib.rs
@@ -8,6 +8,7 @@ Test license
 #![cfg_attr(target_arch = "tricore", feature(stdsimd))]
 
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![doc = "SVD Test for Rust PAC generator"]
 pub mod common;
 pub use common::*;

--- a/test_reference/aurix_tracing/src/lib.rs
+++ b/test_reference/aurix_tracing/src/lib.rs
@@ -8,6 +8,7 @@ Test license
 #![cfg_attr(target_arch = "tricore", feature(stdsimd))]
 
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![doc = "SVD Test for Rust PAC generator"]
 pub mod common;
 pub use common::*;

--- a/test_reference/cortex_m/test_pac/src/lib.rs
+++ b/test_reference/cortex_m/test_pac/src/lib.rs
@@ -5,6 +5,7 @@ Test license
 // Generated from SVD 1.2, with svd2pac 0.7.0 on Fri, 8 May 2026 12:32:27 +0000
 #![no_std]
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![doc = "SVD Test for Rust PAC generator"]
 pub mod common;
 pub use common::*;

--- a/test_reference/cortex_m/test_pac/src/timer.rs
+++ b/test_reference/cortex_m/test_pac/src/timer.rs
@@ -2,7 +2,7 @@
 Test license
 
 */
-// Generated from SVD 1.2, with svd2pac 0.7.0 on Fri, 8 May 2026 12:32:27 +0000
+// Generated from SVD 1.2, with svd2pac 0.7.0 on Tue, 12 May 2026 17:14:35 +0000
 
 #![allow(clippy::identity_op)]
 #![allow(clippy::module_inception)]
@@ -136,6 +136,17 @@ impl super::Timer {
             crate::common::Reg::<self::Register64Bit_SPEC, crate::common::RW>::from_ptr(
                 self._svd2pac_as_ptr().add(96usize),
             )
+        }
+    }
+
+    #[doc = "Register with double underscore in name"]
+    #[inline(always)]
+    pub const fn register_with_double__underscore(
+        &self,
+    ) -> &'static crate::common::Reg<self::RegisterWithDoubleUnderscore_SPEC, crate::common::RW>
+    {
+        unsafe {
+            crate::common::Reg::<self::RegisterWithDoubleUnderscore_SPEC, crate::common::RW>::from_ptr(self._svd2pac_as_ptr().add(112usize))
         }
     }
 
@@ -743,6 +754,50 @@ pub mod register64bit {
         pub const FALSE: Self = Self::new(0);
     }
 }
+#[doc(hidden)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RegisterWithDoubleUnderscore_SPEC;
+impl crate::sealed::RegSpec for RegisterWithDoubleUnderscore_SPEC {
+    type DataType = u32;
+}
+
+#[doc = "Register with double underscore in name"]
+pub type RegisterWithDoubleUnderscore = crate::RegValueT<RegisterWithDoubleUnderscore_SPEC>;
+
+impl RegisterWithDoubleUnderscore {
+    #[doc = "Field with double underscore in name"]
+    #[inline(always)]
+    pub fn field_with_double__underscore(
+        self,
+    ) -> crate::common::RegisterField<
+        0,
+        0xff,
+        1,
+        0,
+        u8,
+        u8,
+        RegisterWithDoubleUnderscore_SPEC,
+        crate::common::RW,
+    > {
+        crate::common::RegisterField::<
+            0,
+            0xff,
+            1,
+            0,
+            u8,
+            u8,
+            RegisterWithDoubleUnderscore_SPEC,
+            crate::common::RW,
+        >::from_register(self, 0)
+    }
+}
+impl ::core::default::Default for RegisterWithDoubleUnderscore {
+    #[inline(always)]
+    fn default() -> RegisterWithDoubleUnderscore {
+        <crate::RegValueT<RegisterWithDoubleUnderscore_SPEC> as RegisterValue<_>>::new(0)
+    }
+}
+
 #[doc(hidden)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Timer_SPEC;

--- a/test_reference/generic/src/lib.rs
+++ b/test_reference/generic/src/lib.rs
@@ -5,6 +5,7 @@ Test license
 // Generated from SVD 1.2, with svd2pac 0.7.0 on Fri, 8 May 2026 12:35:10 +0000
 #![no_std]
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![doc = "SVD Test for Rust PAC generator"]
 pub mod common;
 pub use common::*;

--- a/test_reference/generic/src/timer.rs
+++ b/test_reference/generic/src/timer.rs
@@ -2,7 +2,7 @@
 Test license
 
 */
-// Generated from SVD 1.2, with svd2pac 0.7.0 on Fri, 8 May 2026 12:35:10 +0000
+// Generated from SVD 1.2, with svd2pac 0.7.0 on Tue, 12 May 2026 17:16:16 +0000
 
 #![allow(clippy::identity_op)]
 #![allow(clippy::module_inception)]
@@ -136,6 +136,17 @@ impl super::Timer {
             crate::common::Reg::<self::Register64Bit_SPEC, crate::common::RW>::from_ptr(
                 self._svd2pac_as_ptr().add(96usize),
             )
+        }
+    }
+
+    #[doc = "Register with double underscore in name"]
+    #[inline(always)]
+    pub const fn register_with_double__underscore(
+        &self,
+    ) -> &'static crate::common::Reg<self::RegisterWithDoubleUnderscore_SPEC, crate::common::RW>
+    {
+        unsafe {
+            crate::common::Reg::<self::RegisterWithDoubleUnderscore_SPEC, crate::common::RW>::from_ptr(self._svd2pac_as_ptr().add(112usize))
         }
     }
 
@@ -743,6 +754,50 @@ pub mod register64bit {
         pub const FALSE: Self = Self::new(0);
     }
 }
+#[doc(hidden)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RegisterWithDoubleUnderscore_SPEC;
+impl crate::sealed::RegSpec for RegisterWithDoubleUnderscore_SPEC {
+    type DataType = u32;
+}
+
+#[doc = "Register with double underscore in name"]
+pub type RegisterWithDoubleUnderscore = crate::RegValueT<RegisterWithDoubleUnderscore_SPEC>;
+
+impl RegisterWithDoubleUnderscore {
+    #[doc = "Field with double underscore in name"]
+    #[inline(always)]
+    pub fn field_with_double__underscore(
+        self,
+    ) -> crate::common::RegisterField<
+        0,
+        0xff,
+        1,
+        0,
+        u8,
+        u8,
+        RegisterWithDoubleUnderscore_SPEC,
+        crate::common::RW,
+    > {
+        crate::common::RegisterField::<
+            0,
+            0xff,
+            1,
+            0,
+            u8,
+            u8,
+            RegisterWithDoubleUnderscore_SPEC,
+            crate::common::RW,
+        >::from_register(self, 0)
+    }
+}
+impl ::core::default::Default for RegisterWithDoubleUnderscore {
+    #[inline(always)]
+    fn default() -> RegisterWithDoubleUnderscore {
+        <crate::RegValueT<RegisterWithDoubleUnderscore_SPEC> as RegisterValue<_>>::new(0)
+    }
+}
+
 #[doc(hidden)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Timer_SPEC;

--- a/test_reference/tracing/src/lib.rs
+++ b/test_reference/tracing/src/lib.rs
@@ -5,6 +5,7 @@ Test license
 // Generated from SVD 1.2, with svd2pac 0.7.0 on Fri, 8 May 2026 12:39:15 +0000
 #![cfg_attr(not(feature = "tracing"), no_std)]
 #![allow(non_camel_case_types)]
+#![allow(non_snake_case)]
 #![doc = "SVD Test for Rust PAC generator"]
 pub mod common;
 pub use common::*;

--- a/test_reference/tracing/src/reg_name.rs
+++ b/test_reference/tracing/src/reg_name.rs
@@ -2,7 +2,7 @@
 Test license
 
 */
-// Generated from SVD 1.2, with svd2pac 0.7.0 on Fri, 8 May 2026 12:39:15 +0000
+// Generated from SVD 1.2, with svd2pac 0.7.0 on Tue, 12 May 2026 17:16:50 +0000
 
 //! Contains perfect hash function that maps form raw addresses to
 //! a string containing the names of all registers that point to an address.
@@ -63,6 +63,9 @@ static REGISTER_NAMES: phf::Map<u64, &'static str> = phf_map! {
     ",
   0x40010060u64 => "
       TIMER.register64bit(),
+    ",
+  0x40010070u64 => "
+      TIMER.register_with_double__underscore(),
     ",
   0x40012000u64 => "
       TIMER.timer(),

--- a/test_reference/tracing/src/timer.rs
+++ b/test_reference/tracing/src/timer.rs
@@ -2,7 +2,7 @@
 Test license
 
 */
-// Generated from SVD 1.2, with svd2pac 0.7.0 on Fri, 8 May 2026 12:39:15 +0000
+// Generated from SVD 1.2, with svd2pac 0.7.0 on Tue, 12 May 2026 17:17:28 +0000
 
 #![allow(clippy::identity_op)]
 #![allow(clippy::module_inception)]
@@ -136,6 +136,17 @@ impl super::Timer {
             crate::common::Reg::<self::Register64Bit_SPEC, crate::common::RW>::from_ptr(
                 self._svd2pac_as_ptr().add(96usize),
             )
+        }
+    }
+
+    #[doc = "Register with double underscore in name"]
+    #[inline(always)]
+    pub const fn register_with_double__underscore(
+        &self,
+    ) -> &'static crate::common::Reg<self::RegisterWithDoubleUnderscore_SPEC, crate::common::RW>
+    {
+        unsafe {
+            crate::common::Reg::<self::RegisterWithDoubleUnderscore_SPEC, crate::common::RW>::from_ptr(self._svd2pac_as_ptr().add(112usize))
         }
     }
 
@@ -743,6 +754,50 @@ pub mod register64bit {
         pub const FALSE: Self = Self::new(0);
     }
 }
+#[doc(hidden)]
+#[derive(Copy, Clone, Eq, PartialEq)]
+pub struct RegisterWithDoubleUnderscore_SPEC;
+impl crate::sealed::RegSpec for RegisterWithDoubleUnderscore_SPEC {
+    type DataType = u32;
+}
+
+#[doc = "Register with double underscore in name"]
+pub type RegisterWithDoubleUnderscore = crate::RegValueT<RegisterWithDoubleUnderscore_SPEC>;
+
+impl RegisterWithDoubleUnderscore {
+    #[doc = "Field with double underscore in name"]
+    #[inline(always)]
+    pub fn field_with_double__underscore(
+        self,
+    ) -> crate::common::RegisterField<
+        0,
+        0xff,
+        1,
+        0,
+        u8,
+        u8,
+        RegisterWithDoubleUnderscore_SPEC,
+        crate::common::RW,
+    > {
+        crate::common::RegisterField::<
+            0,
+            0xff,
+            1,
+            0,
+            u8,
+            u8,
+            RegisterWithDoubleUnderscore_SPEC,
+            crate::common::RW,
+        >::from_register(self, 0)
+    }
+}
+impl ::core::default::Default for RegisterWithDoubleUnderscore {
+    #[inline(always)]
+    fn default() -> RegisterWithDoubleUnderscore {
+        <crate::RegValueT<RegisterWithDoubleUnderscore_SPEC> as RegisterValue<_>>::new(0)
+    }
+}
+
 #[doc(hidden)]
 #[derive(Copy, Clone, Eq, PartialEq)]
 pub struct Timer_SPEC;

--- a/test_svd/simple.xml
+++ b/test_svd/simple.xml
@@ -507,6 +507,23 @@
 						</field>
 					</fields>
 				</register>
+          <register>
+            <name>REGISTER_WITH_DOUBLE__UNDERSCORE</name>
+            <description>Register with double underscore in name</description>
+            <addressOffset>0x70</addressOffset>
+            <access>read-write</access>
+            <resetValue>0x00000000</resetValue>
+            <resetMask>0xFFFFFFFF</resetMask>
+            <fields>
+              <field>
+                <name>FIELD_WITH_DOUBLE__UNDERSCORE</name>
+                <description>Field with double underscore in name</description>
+                <lsb>0</lsb>
+                <msb>7</msb>
+                <access>read-write</access>
+              </field>
+            </fields>
+          </register>
 				<register>
 					<name>TIMER</name>
 					<description>Register to test when peripheral has same name as register</description>


### PR DESCRIPTION
Resolves some warnings in PSOC 6 PACs:

```
warning: method `poc_reg__tim_control` should have a snake case name
    --> pacs/psoc6_01/src/ble.rs:2553:18
     |
2553 |     pub const fn poc_reg__tim_control(
     |                  ^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `poc_reg_tim_control`
     |
     = note: `#[warn(non_snake_case)]` (part of `#[warn(nonstandard_style)]`) on by default

warning: method `data_list_sent_update__status` should have a snake case name
    --> pacs/psoc6_01/src/ble.rs:2721:18
     |
2721 |     pub const fn data_list_sent_update__status(
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `data_list_sent_update_status`

warning: method `data_list_ack_update__status` should have a snake case name
    --> pacs/psoc6_01/src/ble.rs:2733:18
     |
2733 |     pub const fn data_list_ack_update__status(
     |                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `data_list_ack_update_status`
...
```

--- please keep the agreement as part of the PR text ---
By creating this pull request you agree to the terms in CONTRIBUTING.md.
https://github.com/Infineon/svd2pac/blob/main/CONTRIBUTING.md
CONTRIBUTING.md also tells you what to expect in the PR process.
